### PR TITLE
New federal reporting exports

### DIFF
--- a/cllc-interfaces/Dynamics-Autorest/Extensions/EntityDocumentExtensions.cs
+++ b/cllc-interfaces/Dynamics-Autorest/Extensions/EntityDocumentExtensions.cs
@@ -60,7 +60,7 @@ namespace Gov.Lclb.Cllb.Interfaces
         public static string GetDocumentFolderName(this MicrosoftDynamicsCRMadoxioFederalreportexport exportEntity)
         {
             string entityIdCleaned = CleanGuidForSharePoint(exportEntity.AdoxioFederalreportexportid);
-            string folderName = $"event_{entityIdCleaned}";
+            string folderName = $"federalreportexport_{entityIdCleaned}";
             return folderName;
         }
 

--- a/cllc-interfaces/Dynamics-Autorest/Extensions/EntityDocumentExtensions.cs
+++ b/cllc-interfaces/Dynamics-Autorest/Extensions/EntityDocumentExtensions.cs
@@ -57,5 +57,12 @@ namespace Gov.Lclb.Cllb.Interfaces
             return folderName;
         }
 
+        public static string GetDocumentFolderName(this MicrosoftDynamicsCRMadoxioFederalreportexport exportEntity)
+        {
+            string entityIdCleaned = CleanGuidForSharePoint(exportEntity.AdoxioFederalreportexportid);
+            string folderName = $"event_{entityIdCleaned}";
+            return folderName;
+        }
+
     }
 }

--- a/cllc-interfaces/Dynamics-Autorest/Extensions/FederalReportExportExtension.cs
+++ b/cllc-interfaces/Dynamics-Autorest/Extensions/FederalReportExportExtension.cs
@@ -16,7 +16,7 @@ namespace Gov.Lclb.Cllb.Interfaces
     {
 
         /// <summary>
-        /// Add reference to adoxio_events
+        /// Add reference to adoxio_federalreportexport
         /// </summary>
         /// <param name='federalReportExportId'>
         /// key: adoxio_federalreportexportid
@@ -74,7 +74,7 @@ namespace Gov.Lclb.Cllb.Interfaces
             }
             // Construct URL
             var _baseUrl = Client.BaseUri.AbsoluteUri;
-            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "adoxio_events({adoxio_federalreportexportid})/{fieldname}/$ref").ToString();
+            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "adoxio_federalreportexports({adoxio_federalreportexportid})/{fieldname}/$ref").ToString();
             _url = _url.Replace("{adoxio_federalreportexportid}", System.Uri.EscapeDataString(federalReportExportId));
             _url = _url.Replace("{fieldname}", System.Uri.EscapeDataString(fieldname));
             // Create HTTP transport objects
@@ -169,9 +169,9 @@ namespace Gov.Lclb.Cllb.Interfaces
     public partial interface IFederalreportexports
     {
         /// <summary>
-        /// Add reference to adoxio_events
+        /// Add reference to adoxio_federalreportexport
         /// </summary>
-        /// <param name='federalReportId'>
+        /// <param name='federalReportExportId'>
         /// key: adoxio_federalreportexportid
         /// </param>
         /// <param name='fieldname'>
@@ -192,22 +192,22 @@ namespace Gov.Lclb.Cllb.Interfaces
         /// <exception cref="Microsoft.Rest.ValidationException">
         /// Thrown when a required parameter is null
         /// </exception>
-        Task<HttpOperationResponse> AddReferenceWithHttpMessagesAsync(string federalReportId, string fieldname, Odataid odataid = default(Odataid), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+        Task<HttpOperationResponse> AddReferenceWithHttpMessagesAsync(string federalReportExportId, string fieldname, Odataid odataid = default(Odataid), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
     }
 
 
     /// <summary>
-    /// Extension methods for Events.
+    /// Extension methods for FederalReportExport.
     /// </summary>
-    public static partial class EventsExtensions
+    public static partial class FederalReportExportExtension
     {
         /// <summary>
-        /// Add reference to adoxio_events
+        /// Add reference to adoxio_federalreportexport
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
         /// </param>
-        /// <param name='federalReportId'>
+        /// <param name='federalReportExportId'>
         /// key: adoxio_federalreportexportid
         /// </param>
         /// <param name='fieldname'>
@@ -222,13 +222,13 @@ namespace Gov.Lclb.Cllb.Interfaces
         }
 
         /// <summary>
-        /// Add reference to adoxio_events
+        /// Add reference to adoxio_federalreportexport
         /// </summary>
         /// <param name='operations'>
         /// The operations group for this extension method.
         /// </param>
-        /// <param name='eventId'>
-        /// key: adoxio_eventid
+        /// <param name='federalReportExportId'>
+        /// key: adoxio_federalreportid
         /// </param>
         /// <param name='fieldname'>
         /// key: fieldname

--- a/cllc-interfaces/Dynamics-Autorest/Extensions/FederalReportExportExtension.cs
+++ b/cllc-interfaces/Dynamics-Autorest/Extensions/FederalReportExportExtension.cs
@@ -1,0 +1,247 @@
+using Gov.Lclb.Cllb.Interfaces.Models;
+using Microsoft.Rest;
+
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Gov.Lclb.Cllb.Interfaces
+{
+    // Intentional typo in this class name to match name in MS Dynamics
+    public partial class Federalreportexports : IServiceOperations<DynamicsClient>, IFederalreportexports
+    {
+
+        /// <summary>
+        /// Add reference to adoxio_events
+        /// </summary>
+        /// <param name='federalReportExportId'>
+        /// key: adoxio_federalreportexportid
+        /// </param>
+        /// <param name='fieldname'>
+        /// key: fieldname
+        /// </param>
+        /// <param name='odataid'>
+        /// reference value
+        /// </param>
+        /// <param name='customHeaders'>
+        /// Headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        /// <exception cref="System.ArgumentNullException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        /// <return>
+        /// A response object containing the response body and response headers.
+        /// </return>
+        public async Task<HttpOperationResponse> AddReferenceWithHttpMessagesAsync(string federalReportExportId, string fieldname, Odataid odataid = default(Odataid), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken))
+        {
+            if (federalReportExportId == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "federalReportExportId");
+            }
+            if (fieldname == null)
+            {
+                throw new ValidationException(ValidationRules.CannotBeNull, "fieldname");
+            }
+            if (odataid != null)
+            {
+                odataid.Validate();
+            }
+            // Tracing
+            bool _shouldTrace = ServiceClientTracing.IsEnabled;
+            string _invocationId = null;
+            if (_shouldTrace)
+            {
+                _invocationId = ServiceClientTracing.NextInvocationId.ToString();
+                Dictionary<string, object> tracingParameters = new Dictionary<string, object>();
+                tracingParameters.Add("adoxio_federalreportexportid", federalReportExportId);
+                tracingParameters.Add("fieldname", fieldname);
+                tracingParameters.Add("odataid", odataid);
+                tracingParameters.Add("cancellationToken", cancellationToken);
+                ServiceClientTracing.Enter(_invocationId, this, "AddReference", tracingParameters);
+            }
+            // Construct URL
+            var _baseUrl = Client.BaseUri.AbsoluteUri;
+            var _url = new System.Uri(new System.Uri(_baseUrl + (_baseUrl.EndsWith("/") ? "" : "/")), "adoxio_events({adoxio_federalreportexportid})/{fieldname}/$ref").ToString();
+            _url = _url.Replace("{adoxio_federalreportexportid}", System.Uri.EscapeDataString(federalReportExportId));
+            _url = _url.Replace("{fieldname}", System.Uri.EscapeDataString(fieldname));
+            // Create HTTP transport objects
+            var _httpRequest = new HttpRequestMessage();
+            HttpResponseMessage _httpResponse = null;
+            _httpRequest.Method = new HttpMethod("POST");
+            _httpRequest.RequestUri = new System.Uri(_url);
+            // Set Headers
+
+
+            if (customHeaders != null)
+            {
+                foreach (var _header in customHeaders)
+                {
+                    if (_httpRequest.Headers.Contains(_header.Key))
+                    {
+                        _httpRequest.Headers.Remove(_header.Key);
+                    }
+                    _httpRequest.Headers.TryAddWithoutValidation(_header.Key, _header.Value);
+                }
+            }
+
+            // Serialize Request
+            string _requestContent = null;
+            if (odataid != null)
+            {
+                _requestContent = Microsoft.Rest.Serialization.SafeJsonConvert.SerializeObject(odataid, Client.SerializationSettings);
+                _httpRequest.Content = new StringContent(_requestContent, System.Text.Encoding.UTF8);
+                _httpRequest.Content.Headers.ContentType = System.Net.Http.Headers.MediaTypeHeaderValue.Parse("application/json; charset=utf-8");
+            }
+            // Set Credentials
+            if (Client.Credentials != null)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                await Client.Credentials.ProcessHttpRequestAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            }
+            // Send Request
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.SendRequest(_invocationId, _httpRequest);
+            }
+            cancellationToken.ThrowIfCancellationRequested();
+            _httpResponse = await Client.HttpClient.SendAsync(_httpRequest, cancellationToken).ConfigureAwait(false);
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.ReceiveResponse(_invocationId, _httpResponse);
+            }
+            HttpStatusCode _statusCode = _httpResponse.StatusCode;
+            cancellationToken.ThrowIfCancellationRequested();
+            string _responseContent = null;
+            if ((int)_statusCode != 204)
+            {
+                var ex = new HttpOperationException(string.Format("Operation returned an invalid status code '{0}'", _statusCode));
+                try
+                {
+                    _responseContent = await _httpResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
+                    Odataerror _errorBody = Microsoft.Rest.Serialization.SafeJsonConvert.DeserializeObject<Odataerror>(_responseContent, Client.DeserializationSettings);
+                    if (_errorBody != null)
+                    {
+                        ex.Body = _errorBody;
+                    }
+                }
+                catch (JsonException)
+                {
+                    // Ignore the exception
+                }
+                ex.Request = new HttpRequestMessageWrapper(_httpRequest, _requestContent);
+                ex.Response = new HttpResponseMessageWrapper(_httpResponse, _responseContent);
+                if (_shouldTrace)
+                {
+                    ServiceClientTracing.Error(_invocationId, ex);
+                }
+                _httpRequest.Dispose();
+                if (_httpResponse != null)
+                {
+                    _httpResponse.Dispose();
+                }
+                throw ex;
+            }
+            // Create Result
+            var _result = new HttpOperationResponse();
+            _result.Request = _httpRequest;
+            _result.Response = _httpResponse;
+            if (_shouldTrace)
+            {
+                ServiceClientTracing.Exit(_invocationId, _result);
+            }
+            return _result;
+        }
+    }
+
+    public partial interface IFederalreportexports
+    {
+        /// <summary>
+        /// Add reference to adoxio_events
+        /// </summary>
+        /// <param name='federalReportId'>
+        /// key: adoxio_federalreportexportid
+        /// </param>
+        /// <param name='fieldname'>
+        /// key: fieldname
+        /// </param>
+        /// <param name='odataid'>
+        /// reference value
+        /// </param>
+        /// <param name='customHeaders'>
+        /// The headers that will be added to request.
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        /// <exception cref="HttpOperationException">
+        /// Thrown when the operation returned an invalid status code
+        /// </exception>
+        /// <exception cref="Microsoft.Rest.ValidationException">
+        /// Thrown when a required parameter is null
+        /// </exception>
+        Task<HttpOperationResponse> AddReferenceWithHttpMessagesAsync(string federalReportId, string fieldname, Odataid odataid = default(Odataid), Dictionary<string, List<string>> customHeaders = null, CancellationToken cancellationToken = default(CancellationToken));
+    }
+
+
+    /// <summary>
+    /// Extension methods for Events.
+    /// </summary>
+    public static partial class EventsExtensions
+    {
+        /// <summary>
+        /// Add reference to adoxio_events
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='federalReportId'>
+        /// key: adoxio_federalreportexportid
+        /// </param>
+        /// <param name='fieldname'>
+        /// key: fieldname
+        /// </param>
+        /// <param name='odataid'>
+        /// reference value
+        /// </param>
+        public static void AddReference(this IFederalreportexports operations, string federalReportExportId, string fieldname, Odataid odataid = default(Odataid))
+        {
+            operations.AddReferenceAsync(federalReportExportId, fieldname, odataid).GetAwaiter().GetResult();
+        }
+
+        /// <summary>
+        /// Add reference to adoxio_events
+        /// </summary>
+        /// <param name='operations'>
+        /// The operations group for this extension method.
+        /// </param>
+        /// <param name='eventId'>
+        /// key: adoxio_eventid
+        /// </param>
+        /// <param name='fieldname'>
+        /// key: fieldname
+        /// </param>
+        /// <param name='odataid'>
+        /// reference value
+        /// </param>
+        /// <param name='cancellationToken'>
+        /// The cancellation token.
+        /// </param>
+        public static async Task AddReferenceAsync(this IFederalreportexports operations, string federalReportExportId, string fieldname, Odataid odataid = default(Odataid), CancellationToken cancellationToken = default(CancellationToken))
+        {
+            (await operations.AddReferenceWithHttpMessagesAsync(federalReportExportId, fieldname, odataid, null, cancellationToken).ConfigureAwait(false)).Dispose();
+        }
+    }
+}

--- a/cllc-interfaces/Dynamics-Autorest/ModelExtensions/MicrosoftDynamicsCRMadoxioCannabismonthlyreport.cs
+++ b/cllc-interfaces/Dynamics-Autorest/ModelExtensions/MicrosoftDynamicsCRMadoxioCannabismonthlyreport.cs
@@ -1,0 +1,10 @@
+namespace Gov.Lclb.Cllb.Interfaces.Models
+{
+    using Newtonsoft.Json;
+
+    public partial class MicrosoftDynamicsCRMadoxioCannabismonthlyreport
+    {
+        [JsonProperty(PropertyName = "adoxio_FederalReportExportId@odata.bind")]
+        public string AdoxioFederalReportExportIdODateBind { get; set; }
+    }
+}

--- a/cllc-interfaces/Dynamics-Autorest/ModelExtensions/MicrosoftDynamicsCRMsharepointdocumentlocation.cs
+++ b/cllc-interfaces/Dynamics-Autorest/ModelExtensions/MicrosoftDynamicsCRMsharepointdocumentlocation.cs
@@ -22,6 +22,9 @@ namespace Gov.Lclb.Cllb.Interfaces.Models
 
         [JsonProperty(PropertyName = "regardingobjectid_adoxio_event@odata.bind")]
         public string RegardingobjectIdEventODataBind { get; set; }
+        [JsonProperty(PropertyName = "regardingobjectid_adoxio_federalreportexport@odata.bind")]
+        public string RegardingobjectIdFederalReportExportODataBind { get; set; }
+
 
         [JsonProperty(PropertyName = "parentsiteorlocation_sharepointdocumentlocation@odata.bind")]
         public string ParentsiteorlocationSharepointdocumentlocationODataBind { get; set; }

--- a/cllc-interfaces/SharePoint/SharePointFileManager.cs
+++ b/cllc-interfaces/SharePoint/SharePointFileManager.cs
@@ -28,7 +28,8 @@ namespace Gov.Lclb.Cllb.Interfaces
         public const string ContactDocumentListTitle = "contact";
         public const string WorkerDocumentListTitle = "Worker Qualification";
         public const string WorkerDocumentUrlTitle = "adoxio_worker";
-        public const string EventDocumentListTitle = "adoxio_event"; // temporarily using the wrong folder while waiting for permissions
+        public const string EventDocumentListTitle = "adoxio_event";
+        public const string FederalReportListTitle = "Federal Reporting";
 
         private const int MaxUrlLength = 260; // default maximum URL length.
 

--- a/cllc-interfaces/SharePoint/SharePointFileManager.cs
+++ b/cllc-interfaces/SharePoint/SharePointFileManager.cs
@@ -29,7 +29,7 @@ namespace Gov.Lclb.Cllb.Interfaces
         public const string WorkerDocumentListTitle = "Worker Qualification";
         public const string WorkerDocumentUrlTitle = "adoxio_worker";
         public const string EventDocumentListTitle = "adoxio_event";
-        public const string FederalReportListTitle = "Federal Reporting";
+        public const string FederalReportListTitle = "adoxio_federalreportexport";
 
         private const int MaxUrlLength = 260; // default maximum URL length.
 

--- a/cllc-public-app/Extensions/FileManagerClient.cs
+++ b/cllc-public-app/Extensions/FileManagerClient.cs
@@ -9,7 +9,7 @@ namespace Gov.Lclb.Cllb.Services.FileManager {
   /// <summary>
   /// The files service definition.
   /// </summary>
-  public static partial class FileManager{
+  public static partial class FileManager {
         public const string DefaultDocumentListTitle = "Account";
         public const string AccountDocumentUrlTitle = "account";
         public const string ApplicationDocumentListTitle = "Application";

--- a/cllc-public-app/Startup.cs
+++ b/cllc-public-app/Startup.cs
@@ -289,9 +289,7 @@ namespace Gov.Lclb.Cllb.Public
                     services.AddTransient<FileManagerClient>(_ => new FileManagerClient(channel));
 
                 }
-
-
-            }            
+            }
 
         }
 

--- a/federal-reporting-service/FederalReportingController.cs
+++ b/federal-reporting-service/FederalReportingController.cs
@@ -23,7 +23,7 @@ namespace Gov.Lclb.Cllb.FederalReportingService
 {
     public class FederalReportingController
     {
-        private readonly string DOCUMENT_LIBRARY = "Federal Reporting";
+        private readonly string DOCUMENT_LIBRARY = "adoxio_federalreportexport";
         private readonly IDynamicsClient _dynamicsClient;
         private readonly IConfiguration _configuration;
         private readonly FileManagerClient _fileManagerClient;
@@ -128,7 +128,7 @@ namespace Gov.Lclb.Cllb.FederalReportingService
                                 {
                                     folderName = export.GetDocumentFolderName();
 
-                                    CreateFederalReportDocumentLocation(export, folderName, filename);
+                                    CreateFederalReportDocumentLocation(export, DOCUMENT_LIBRARY, folderName);
                                 }
                                 // string sharepointFilename = await _sharepoint.UploadFile(filename, DOCUMENT_LIBRARY, "", mem, "text/csv");
                                 // string url = _sharepoint.GetServerRelativeURL(DOCUMENT_LIBRARY, "");
@@ -140,7 +140,7 @@ namespace Gov.Lclb.Cllb.FederalReportingService
                                     Data = ByteString.CopyFrom(data),
                                     EntityName = "federal_report",
                                     FileName = filename,
-                                    FolderName = DOCUMENT_LIBRARY
+                                    FolderName = folderName
                                 };
 
                                 var uploadResult = _fileManagerClient.UploadFile(uploadRequest);
@@ -187,7 +187,7 @@ namespace Gov.Lclb.Cllb.FederalReportingService
             {
 
                 // set the parent document library.
-                string parentDocumentLibraryReference = GetDocumentLocationReferenceByRelativeURL("Federal Reporting", name);
+                string parentDocumentLibraryReference = GetDocumentLocationReferenceByRelativeURL("adoxio_federalreportexport", name);
 
                 string exportUri = _dynamicsClient.GetEntityURI("adoxio_federalreportexports", federalReport.AdoxioFederalreportexportid);
                 // add a regardingobjectid.
@@ -195,7 +195,7 @@ namespace Gov.Lclb.Cllb.FederalReportingService
                 {
                     RegardingobjectIdFederalReportExportODataBind = exportUri,
                     ParentsiteorlocationSharepointdocumentlocationODataBind = _dynamicsClient.GetEntityURI("sharepointdocumentlocations", parentDocumentLibraryReference),
-                    Relativeurl = folderName,
+                    Relativeurl = name,
                     Description = "Federal Report Files",
                 };
 
@@ -217,7 +217,7 @@ namespace Gov.Lclb.Cllb.FederalReportingService
 
                 try
                 {
-                    _dynamicsClient.Federalreportexports.AddReference(federalReport.AdoxioFederalreportexportid, "adoxio_documentlink", oDataId);
+                    _dynamicsClient.Federalreportexports.AddReference(federalReport.AdoxioFederalreportexportid, "adoxio_federalreportexport_SharePointDocumentLocations", oDataId);
                 }
                 catch (HttpOperationException odee)
                 {

--- a/federal-reporting-service/FederalReportingController.cs
+++ b/federal-reporting-service/FederalReportingController.cs
@@ -39,6 +39,17 @@ namespace Gov.Lclb.Cllb.FederalReportingService
             _logger = loggerFactory.CreateLogger(typeof(FederalReportingController));
         }
 
+        public async Task ExportFederalReports(PerformContext hangfireContext)
+        {
+            // Get any new exports that have been created
+            // Gather submitted reports
+            // Get inventory reports for those submitted reports
+            // Attach monthly report to export record
+            // Create CSV file
+            // Export file to Sharepoint
+            // Update export record with results (monthly reports, export triggered date, export completed date, document link)
+        }
+
 
         /// <summary>
         /// Generate a csv with the federal tracking report for a given reporting period

--- a/federal-reporting-service/Startup.cs
+++ b/federal-reporting-service/Startup.cs
@@ -154,8 +154,8 @@ namespace Gov.Lclb.Cllb.FederalReportingService
                 {
                     log.LogInformation($"Creating Hangfire jobs for {typeof(Startup)} ...");
 
-                    // Run 1 minute past midnight on the 15th of every month
-                    RecurringJob.AddOrUpdate(() => new FederalReportingController(Configuration, loggerFactory).GenerateFederalTrackingReport(null), "1 8 15 * *");
+                    // Run every 10 minutes
+                    RecurringJob.AddOrUpdate(() => new FederalReportingController(Configuration, loggerFactory).ExportFederalReports(null), "*/10 * * * *");
 
                     log.LogInformation("Hangfire jobs setup.");
                 }

--- a/federal-reporting-service/Startup.cs
+++ b/federal-reporting-service/Startup.cs
@@ -31,10 +31,11 @@ namespace Gov.Lclb.Cllb.FederalReportingService
         private readonly ILoggerFactory _loggerFactory;
         public IConfiguration Configuration { get; }
         public IWebHostEnvironment _env { get; set; }
-        public _fileManagerClient FileManagerClient { get; set; }
+        public FileManagerClient _fileManagerClient { get; set; }
 
         public Startup(IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
+            _env = env;
             _loggerFactory = loggerFactory;
 
             var builder = new ConfigurationBuilder()

--- a/federal-reporting-service/Startup.cs
+++ b/federal-reporting-service/Startup.cs
@@ -19,6 +19,10 @@ using Microsoft.Extensions.Hosting;
 using Serilog;
 using Serilog.Exceptions;
 using System.Net.Http;
+using System.Net;
+using Grpc.Net.Client;
+using static Gov.Lclb.Cllb.Services.FileManager.FileManager;
+using Gov.Lclb.Cllb.Services.FileManager;
 
 namespace Gov.Lclb.Cllb.FederalReportingService
 {
@@ -26,6 +30,8 @@ namespace Gov.Lclb.Cllb.FederalReportingService
     {
         private readonly ILoggerFactory _loggerFactory;
         public IConfiguration Configuration { get; }
+        public IWebHostEnvironment _env { get; set; }
+        public _fileManagerClient FileManagerClient { get; set; }
 
         public Startup(IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
@@ -62,6 +68,52 @@ namespace Gov.Lclb.Cllb.FederalReportingService
             // health checks. 
             services.AddHealthChecks()
                 .AddCheck("Federal Reporting Service", () => HealthCheckResult.Healthy());
+
+                // add the file manager.
+            string fileManagerURI = Configuration["FILE_MANAGER_URI"];
+            if (!_env.IsProduction()) // needed for macOS TLS being turned off
+            {
+                AppContext.SetSwitch("System.Net.Http.SocketsHttpHandler.Http2UnencryptedSupport", true);
+            }
+            if (!string.IsNullOrEmpty (fileManagerURI))
+            {
+                var httpClientHandler = new HttpClientHandler();
+
+                if (!_env.IsProduction()) // Ignore certificate errors in non-production modes.  
+                                         // This allows you to use OpenShift self-signed certificates for testing.
+                {
+                    // Return `true` to allow certificates that are untrusted/invalid                    
+                    httpClientHandler.ServerCertificateCustomValidationCallback =
+                    HttpClientHandler.DangerousAcceptAnyServerCertificateValidator;
+                }
+                
+                var httpClient = new HttpClient(httpClientHandler);
+                // set default request version to HTTP 2.  Note that Dotnet Core does not currently respect this setting for all requests.
+                httpClient.DefaultRequestVersion = HttpVersion.Version20;
+              
+                var initialChannel = GrpcChannel.ForAddress(fileManagerURI, new GrpcChannelOptions { HttpClient = httpClient });
+                
+                var initialClient = new FileManagerClient(initialChannel);
+                // call the token service to get a token.
+                var tokenRequest = new TokenRequest()
+                {
+                    Secret = Configuration["FILE_MANAGER_SECRET"]
+                };
+
+                var tokenReply = initialClient.GetToken(tokenRequest);
+
+                if (tokenReply != null && tokenReply.ResultStatus == ResultStatus.Success)
+                {
+                    // Add the bearer token to the client.
+                    
+                    httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {tokenReply.Token}");
+
+                    var channel = GrpcChannel.ForAddress(fileManagerURI, new GrpcChannelOptions() { HttpClient = httpClient });                   
+                    _fileManagerClient = new FileManagerClient(channel);
+                    services.AddTransient<FileManagerClient>(_ => _fileManagerClient);
+
+                }
+            }
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -155,7 +207,7 @@ namespace Gov.Lclb.Cllb.FederalReportingService
                     log.LogInformation($"Creating Hangfire jobs for {typeof(Startup)} ...");
 
                     // Run every 10 minutes
-                    RecurringJob.AddOrUpdate(() => new FederalReportingController(Configuration, loggerFactory).ExportFederalReports(null), "*/10 * * * *");
+                    RecurringJob.AddOrUpdate(() => new FederalReportingController(Configuration, loggerFactory, _fileManagerClient).ExportFederalReports(null), "*/10 * * * *");
 
                     log.LogInformation("Hangfire jobs setup.");
                 }

--- a/federal-reporting-service/federal-reporting-service.csproj
+++ b/federal-reporting-service/federal-reporting-service.csproj
@@ -22,11 +22,11 @@
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.6.3" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
     <PackageReference Include="Microsoft.Extensions.HealthChecks" Version="1.0.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.1.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="3.2.0" />
     <PackageReference Include="Serilog" Version="2.9.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Splunk" Version="3.3.0" />
-    <PackageReference Include="Serilog.Exceptions" Version="5.3.1" />
+    <PackageReference Include="Serilog.Exceptions" Version="5.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/federal-reporting-service/federal-reporting-service.csproj
+++ b/federal-reporting-service/federal-reporting-service.csproj
@@ -11,6 +11,11 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Grpc.AspNetCore" Version="2.26.0" />
+    <PackageReference Include="Grpc.Tools" Version="2.25.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="CsvHelper" Version="12.2.1" />
     <PackageReference Include="Hangfire" Version="1.7.7" />
     <PackageReference Include="Hangfire.Console" Version="1.4.2" />
@@ -22,6 +27,16 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />
     <PackageReference Include="Serilog.Sinks.Splunk" Version="3.3.0" />
     <PackageReference Include="Serilog.Exceptions" Version="5.3.1" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Protobuf Include="..\file-manager-service\Protos\fileManager.proto" GrpcServices="Client">
+      <Link>gRPC Prototypes\fileManager.proto</Link>
+    </Protobuf>
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\file-manager-service\file-manager-service.csproj" />
   </ItemGroup>
 
   <PropertyGroup>

--- a/file-manager-service/Services/FileManagerService.cs
+++ b/file-manager-service/Services/FileManagerService.cs
@@ -148,6 +148,9 @@ namespace Gov.Lclb.Cllb.Services.FileManager
                 case "event":
                     listTitle = SharePointFileManager.EventDocumentListTitle;
                     break;
+                case "federal_report":
+                    listTitle = SharePointFileManager.FederalReportListTitle;
+                    break;
                 default:
                     listTitle = entityName;
                     break;
@@ -174,6 +177,9 @@ namespace Gov.Lclb.Cllb.Services.FileManager
                     break;
                 case "event":
                     listTitle = SharePointFileManager.EventDocumentListTitle;
+                    break;
+                case "federal_report":
+                    listTitle = SharePointFileManager.FederalReportListTitle;
                     break;
                 default:
                     break;


### PR DESCRIPTION
This adds federal reporting export entities to keep track of monthly reports that are included in each report. It also allows admins to generate exports by creating a new export record.

This service now uses the File Manager Service for uploads to sharepoint