### PR TITLE
validation message on licence # for covid

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/application-covid-temporary-extension/application-covid-temporary-extension.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application-covid-temporary-extension/application-covid-temporary-extension.component.html
@@ -38,9 +38,8 @@
             <section class="padded-section content-bottom">
 
                 <app-field label="Licence Number" [valid]="isValidOrNotTouched('description1')"
-                    errorMessage="Licence Number is a required field">
-                    <input class="form-control" type="text" maxlength="7"
-                        formControlName="description1" mask="000000">
+                    errorMessage="Licence Number is a required field and must contain 6 digits">
+                    <input class="form-control" type="text" formControlName="description1" mask="000000">
                 </app-field>
 
                 <app-field label="Licence Type" [valid]="isValidOrNotTouched('licenceType')" [showChevrons]="false"

--- a/cllc-public-app/ClientApp/src/app/components/applications/application-covid-temporary-extension/application-covid-temporary-extension.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application-covid-temporary-extension/application-covid-temporary-extension.component.ts
@@ -67,7 +67,7 @@ export class ApplicationCovidTemporaryExtensionComponent extends FormBase implem
 
   ngOnInit() {
     this.form = this.fb.group({
-      description1: ['', [Validators.required, Validators.maxLength(7)]], //this holds the licenceNumber
+      description1: ['', [Validators.required, Validators.maxLength(6)]], //this holds the licenceNumber
       licenceType: ['', [Validators.required]],
       nameOfApplicant: ['', [Validators.required]],
       establishmentName: ['', [Validators.required]],


### PR DESCRIPTION
Previous code was conflicting max length of 6 from mask and 7 from validation. Went with the smaller number as that was the limiter before. Error message now helps users