### PR TITLE
Adjust payment confirmation such that the initial page render complet…

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/payment-confirmation/payment-confirmation.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/payment-confirmation/payment-confirmation.component.ts
@@ -50,6 +50,10 @@ export class PaymentConfirmationComponent implements OnInit {
     if (!this.applicationId) {
       this.applicationId = this.inputApplicationId;
     }
+    
+  }
+
+  ngAfterViewInit() {
     this.verify_payment();
   }
 


### PR DESCRIPTION
Adjust payment confirmation such that the initial page render completes before the verify payment starts.  This way the page will still load if there is a problem connecting to Bambora or Dynamics.