### PR TITLE
LCSD-3549 - remove deemed licences

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
@@ -167,20 +167,20 @@ export class ApplicationComponent extends FormBase implements OnInit {
       establishmentAddressPostalCode: ['', [Validators.required, Validators.pattern(CanadaPostalRegex)]],
       establishmentEmail: ['', Validators.email],
       establishmentPhone: [''],
-      serviceHoursSundayOpen: ['', Validators.required],
-      serviceHoursMondayOpen: ['', Validators.required],
-      serviceHoursTuesdayOpen: ['', Validators.required],
-      serviceHoursWednesdayOpen: ['', Validators.required],
-      serviceHoursThursdayOpen: ['', Validators.required],
-      serviceHoursFridayOpen: ['', Validators.required],
-      serviceHoursSaturdayOpen: ['', Validators.required],
-      serviceHoursSundayClose: ['', Validators.required],
-      serviceHoursMondayClose: ['', Validators.required],
-      serviceHoursTuesdayClose: ['', Validators.required],
-      serviceHoursWednesdayClose: ['', Validators.required],
-      serviceHoursThursdayClose: ['', Validators.required],
-      serviceHoursFridayClose: ['', Validators.required],
-      serviceHoursSaturdayClose: ['', Validators.required],
+      serviceHoursSundayOpen: [''],
+      serviceHoursMondayOpen: [''],
+      serviceHoursTuesdayOpen: [''],
+      serviceHoursWednesdayOpen: [''],
+      serviceHoursThursdayOpen: [''],
+      serviceHoursFridayOpen: [''],
+      serviceHoursSaturdayOpen: [''],
+      serviceHoursSundayClose: [''],
+      serviceHoursMondayClose: [''],
+      serviceHoursTuesdayClose: [''],
+      serviceHoursWednesdayClose: [''],
+      serviceHoursThursdayClose: [''],
+      serviceHoursFridayClose: [''],
+      serviceHoursSaturdayClose: [''],
       liquorDeclarationCheck: [''],
       applyAsIndigenousNation: [false],
       indigenousNationId: [{ value: null, disabled: true }, Validators.required],
@@ -342,6 +342,10 @@ export class ApplicationComponent extends FormBase implements OnInit {
     this.dynamicsDataService.getRecord('indigenousnations', '')
       .subscribe(data => this.indigenousNations = data);
 
+  }
+
+  hoursChanged() {
+    console.log('')
   }
 
   autocompleteDisplay(item: any) {

--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
@@ -344,10 +344,6 @@ export class ApplicationComponent extends FormBase implements OnInit {
 
   }
 
-  hoursChanged() {
-    console.log('')
-  }
-
   autocompleteDisplay(item: any) {
     return item && item.name;
   }

--- a/cllc-public-app/ClientApp/src/app/components/dashboard/applications-and-licences/applications-and-licences.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/dashboard/applications-and-licences/applications-and-licences.component.html
@@ -211,7 +211,7 @@
               <!-- <th style="width: 95px">Last Updated</th> -->
               <th style="width: 235px">Status</th>
               <th>Actions</th>
-              <th>Apply for Enforsements</th>
+              <th>Apply for Endorsements</th>
             </tr>
             <tr *ngFor="let item of inProgressApplications; let i = index;" style="border: 1px solid #ccc; ">
               <td style="background-color: #E1E8F2; padding: 10px; width: 15px;"><span>{{i+1}}</span></td>

--- a/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.html
@@ -26,9 +26,6 @@
 
                 <td style="padding: 10px;">
                     <div>
-                    <div *ngIf="item?.isDeemed">
-                        <strong>DEEMED</strong>
-                    </div>
                     <strong *ngIf="item?.licenceTypeName !== 'Marketing'" style="color: #1a5a96;">
                         {{item.establishmentName}}</strong>
                     <div *ngIf="item?.licenseSubCategory">
@@ -119,7 +116,7 @@
                     </div>
                     <!-- Third Party Operator Actions-->
                     <!-- Indicate application has been initiated-->
-                    <div *ngIf="isActive(item) && !item.isDeemed && item.tpoRequested" class="licence-expired">
+                    <div *ngIf="isActive(item) && item.tpoRequested" class="licence-expired">
                         <strong>Third Party Operator Application Initiated</strong> <br />
                         <section
                             *ngIf="isActive(item) && item.tpoRequested"

--- a/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.html
@@ -163,7 +163,7 @@
                 <td style="background-color: #E1E8F2; padding: 10px;">
                     <!-- 3rd Party Operators cannot submit  changes -->
                     <div *ngIf="!item.isOperated">
-                        <div *ngIf="isActive(item) && !item.transferRequested">
+                        <div *ngIf="isActive(item) && actionsVisible(item) && !item.transferRequested">
                             <p>
                                 <a [routerLink]="[ '/ownership-transfer/' + item.licenseId]">
                                 <span><i class="fas fa-exchange-alt" style="margin-right: 10px;"></i>Transfer Licence</span>
@@ -171,7 +171,7 @@
                             </p>
                         </div>
                         <!-- if there is a third party application in progress, we don't show the ability to submit a new application-->
-                        <div *ngIf="isActive(item) && !item.tpoRequested && item.licenceTypeCategory === 'Liquor'">
+                        <div *ngIf="isActive(item) && actionsVisible(item) && !item.tpoRequested && item.licenceTypeCategory === 'Liquor'">
                             <p>
                                 <a [routerLink]="[ '/third-party-operator/' + item.licenseId]">
                                 <span><i class="fas fa-exchange-alt" style="margin-right: 10px;"></i>Add or Change a Third Party Operator</span>

--- a/cllc-public-app/ClientApp/src/app/components/licences/licences.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/licences/licences.component.ts
@@ -71,19 +71,15 @@ export class LicencesComponent extends FormBase implements OnInit {
     this.busy =
       forkJoin(this.applicationDataService.getAllCurrentApplications(),
         this.licenceDataService.getAllCurrentLicenses(),
-        this.licenceDataService.getAllOperatedLicenses(),
-        this.licenceDataService.getAllProposedLicenses()
+        this.licenceDataService.getAllOperatedLicenses()
       ).pipe(takeWhile(() => this.componentActive))
-        .subscribe(([applications, licenses, operatedLicences, proposedLicences]) => {
+        .subscribe(([applications, licenses, operatedLicences]) => {
           this.applications = applications;
           operatedLicences.forEach(licence => {
             licence.isOperated = true;
             licence.licenceTypeName = 'Operated - ' + licence.licenceTypeName;
           });
-          proposedLicences.forEach(licence => {
-            licence.isDeemed = true;
-          });
-          const combinedLicences = [...licenses, ...operatedLicences, ...proposedLicences];
+          const combinedLicences = [...licenses, ...operatedLicences];
           combinedLicences.forEach((licence: ApplicationLicenseSummary) => {
             licence.headerRowSpan = 1;
             this.addOrUpdateLicence(licence);

--- a/cllc-public-app/Controllers/AccountsController.cs
+++ b/cllc-public-app/Controllers/AccountsController.cs
@@ -150,7 +150,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
                     filter = $"contains(name,'{name}')";
                 }
                 var expand = new List<string> { "primarycontactid" };
-                var accounts = _dynamicsClient.Accounts.Get(filter: filter, expand: expand).Value;
+                var accounts = _dynamicsClient.Accounts.Get(filter: filter, expand: expand, top: 10).Value;
                 foreach (var account in accounts)
                 {
                     var transferAccount = new TransferAccount()


### PR DESCRIPTION
This removes the licences that an account is "deemed" so it will no longer show on a user's licence dashboard when they are being transferred a licence.

Is there a way for licencees to pay for a transfer? Right now I think they might just be getting lost as a transfer doesn't create an application