### PR TITLE
LCSD-3968 Off-site storage fixes

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.html
@@ -79,17 +79,18 @@
                                 <p *ngIf="item.operated && !item.isOperated"><i class="fas fa-flag"
                                         style="margin-right: 10px;"></i>Licence Operated</p>
                             </div>
+                            <br>
                             <div *ngIf="item.licenceTypeCategory === 'Liquor' && isActive(item) && actionsVisible(item) && !item.isOperated">
-                                <br>
-                                <a [routerLink]="[ '/licence/' + item.licenseId + '/representative']">
-                                    <span *ngIf="!item.representativeFullName">Add Licensee Representative</span>
-                                    <span *ngIf="item.representativeFullName">Licensee Representative:
-                                        <strong>{{item.representativeFullName}}</strong></span>
-                                </a>
-                                <br>
-                                <a [routerLink]="[ '/licence/' + item.licenseId + '/offsite-storage']">Manage Off-Site Storage</a>
-                          </div>
-                        </td>
+                              <a [routerLink]="[ '/licence/' + item.licenseId + '/representative']">
+                                  <span *ngIf="!item.representativeFullName">Add Licensee Representative</span>
+                                  <span *ngIf="item.representativeFullName">Licensee Representative:
+                                      <strong>{{item.representativeFullName}}</strong></span>
+                              </a>
+                            </div>
+                            <div *ngIf="showManageOffsiteStorage(item)">
+                              <a [routerLink]="[ '/licence/' + item.licenseId + '/offsite-storage']">Manage Off-Site Storage</a>
+                            </div>
+                      </td>
 
                         <td style="padding: 10px;">
                             <div *ngIf="item?.licenceTypeName !== 'Marketing'">

--- a/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.ts
@@ -155,6 +155,23 @@ export class LicenceRowComponent extends FormBase implements OnInit {
     return true;
   }
 
+  /**
+   * The off-site storage feature is available for all *liquor* licences except for:
+   *   - Catering
+   *   - UBrew/UVin
+   *   - Agent
+   * It should not be available for any Cannabis licence type.
+   */
+  showManageOffsiteStorage(item: ApplicationLicenseSummary) {
+    const exclusions = [ApplicationTypeNames.Catering, ApplicationTypeNames.UBV] as string[];
+    const result = this.isActive(item)
+      && this.actionsVisible(item)
+      && item.licenceTypeCategory === 'Liquor'
+      && !exclusions.includes(item.licenceTypeName)
+      && !item.isOperated;
+    return result;
+  }
+
   showLicenceTransferAction(item: ApplicationLicenseSummary) {
     const result = this.isActive(item)
       && !item.transferRequested
@@ -162,7 +179,6 @@ export class LicenceRowComponent extends FormBase implements OnInit {
       && item.licenceTypeName !== 'Section 119 Authorization';
     return result;
   }
-
 
   showAddOrChangeThirdPartyOperator(item: ApplicationLicenseSummary): boolean {
     const result = this.isActive(item)

--- a/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
@@ -26,9 +26,6 @@
     <section class="padded-section content-bottom">
       <p>Please provide the following information for each of your off-site storage facilities, including storage unit numbers if applicable:</p>
       <app-offsite-table formControlName="offsiteStorageLocations" [enabled]="true" [shouldValidate]="showValidationMessages"></app-offsite-table>
-      <!-- <app-field [valid]="!showValidationMessages || form.get('offsiteStorageLocations').valid"
-        errorMessage="All fields are required." [showChevrons]="false" [isFullWidth]="true">
-      </app-field> -->
     </section>
 
     <h3 class="blue-header">DECLARATIONS</h3>

--- a/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
@@ -26,8 +26,8 @@
     <section class="padded-section content-bottom">
       <p>Please provide the following information for each of your off-site storage facilities, including storage unit numbers if applicable:</p>
       <app-field [valid]="!showValidationMessages || form.get('offsiteStorageLocations').valid"
-                errorMessage="All fields are required." [showChevrons]="false" [isFullWidth]="true">
-        <app-offsite-table formControlName="offsiteStorageLocations" [enabled]="true"></app-offsite-table>
+        errorMessage="All fields are required." [showChevrons]="false" [isFullWidth]="true">
+        <app-offsite-table formControlName="offsiteStorageLocations" [enabled]="true" [shouldValidate]="showValidationMessages"></app-offsite-table>
       </app-field>
     </section>
 
@@ -39,8 +39,7 @@
       </p>
       <div>
         <app-field [valid]="!showValidationMessages || form.get('agreement').valid"
-          errorMessage="Please affirm that all of the information provided is true and complete."
-          [showChevrons]="false">
+          errorMessage="Please affirm that all of the information provided is true and complete." [showChevrons]="false">
           <mat-checkbox formControlName="agreement">I understand and affirm that all of the information provided is true and complete.</mat-checkbox>
         </app-field>
       </div>

--- a/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
@@ -51,9 +51,9 @@
     </section>
 
     <div class="p-4 button-row">
-      <button type="button" class="btn btn-primary" style="margin-right:10px;" (click)="cancel();">
+      <button type="button" class="btn btn-secondary" style="margin-right:10px;" (click)="cancel();">
         <span>
-          <i class="fa fa-trash" style="color: #fff;"></i>
+          <i class="fa fa-trash" style="color: #003366;"></i>
           CANCEL
         </span>
       </button>

--- a/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
@@ -25,10 +25,10 @@
     <h3 class="blue-header">Off-Site Storage Locations</h3>
     <section class="padded-section content-bottom">
       <p>Please provide the following information for each of your off-site storage facilities, including storage unit numbers if applicable:</p>
-      <app-field [valid]="!showValidationMessages || form.get('offsiteStorageLocations').valid"
+      <app-offsite-table formControlName="offsiteStorageLocations" [enabled]="true" [shouldValidate]="showValidationMessages"></app-offsite-table>
+      <!-- <app-field [valid]="!showValidationMessages || form.get('offsiteStorageLocations').valid"
         errorMessage="All fields are required." [showChevrons]="false" [isFullWidth]="true">
-        <app-offsite-table formControlName="offsiteStorageLocations" [enabled]="true" [shouldValidate]="showValidationMessages"></app-offsite-table>
-      </app-field>
+      </app-field> -->
     </section>
 
     <h3 class="blue-header">DECLARATIONS</h3>

--- a/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.html
@@ -1,6 +1,6 @@
 <div class="form-wrapper" style="position: relative;">
   <div [ngBusy]="[busy]"></div>
-  <form [formGroup]="form">
+  <form [formGroup]="form" class="col-lg-7 col-sm-12">
     <div class="padded-section">
       <h1>Manage Off-Site Storage</h1>
     </div>

--- a/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/offsite-storage/offsite-storage.component.ts
@@ -25,7 +25,7 @@ export class OffsiteStorageComponent extends FormBase implements OnInit {
   form = this.fb.group({
     licenseId: ['', []],
     offsiteStorageLocations: ['', []],
-    agreement: [false, [Validators.required]]
+    agreement: [false, [this.customRequiredCheckboxValidator()]]
   });
 
   constructor(
@@ -74,10 +74,9 @@ export class OffsiteStorageComponent extends FormBase implements OnInit {
     if (this.isFormInvalid()) {
       this.showValidationMessages = true;
       this.markControlsAsTouched(this.form);
-      return;
+    } else {
+      this.updateLicence();
     }
-
-    this.updateLicence();
   }
 
   updateLicence() {

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
@@ -1,6 +1,7 @@
 <table class="capacity">
   <thead *ngIf="rows.controls.length > 0">
     <th style="width: 100px">Status</th>
+    <th>Location Name</th>
     <th>Address</th>
     <th>City</th>
     <th style="width: 200px">Postal Code</th>
@@ -9,6 +10,12 @@
   <tr *ngFor="let row of rows.controls; let i=index" [ngClass]="{ 'text-grey': !canEdit(i) }">
     <ng-container [formGroup]="row">
       <td><span class="bold">{{ offsiteStorageStatus[row.value.status] }}</span></td>
+      <td>
+        <app-field [valid]="!shouldValidate || !row.get('name').value || row.get('name').valid"
+          errorMessage="Cannot exceed 250 characters" [showChevrons]="false" [isFullWidth]="true">
+          <input type="text" formControlName="name" placeholder="Enter a name for this location" [readonly]="!canEdit(i)"/>
+        </app-field>
+      </td>
       <td><input type="text" formControlName="street1" placeholder="Enter Address" [readonly]="!canEdit(i)"/></td>
       <td><input type="text" formControlName="city" placeholder="Enter City" [readonly]="!canEdit(i)"/></td>
       <td><input type="text" formControlName="postalCode" placeholder="Enter Postal Code" [readonly]="!canEdit(i)"/></td>
@@ -21,6 +28,7 @@
         <i class="fa fa-plus-circle" style="color: #1a5a96;"></i> Add Additional Storage
       </button>
     </td>
+    <td></td>
     <td></td>
     <td></td>
     <td></td>

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
@@ -1,4 +1,4 @@
-<table class="capacity">
+<table class="offsite-storage">
   <thead *ngIf="rows.controls.length > 0">
     <th style="width: 100px">Status</th>
     <th>Location Name</th>
@@ -7,19 +7,19 @@
     <th style="width: 200px">Postal Code</th>
     <th style="width: 45px"></th>
   </thead>
-  <tr *ngFor="let row of rows.controls; let i=index" [ngClass]="{ 'text-grey': !canEdit(i) }">
+  <tr *ngFor="let row of rows.controls; let i=index" [ngClass]="{ 'text-grey': readonly(i) }">
     <ng-container [formGroup]="row">
       <td><span class="bold">{{ offsiteStorageStatus[row.value.status] }}</span></td>
       <td>
-        <app-field [valid]="!shouldValidate || !row.get('name').value || row.get('name').valid"
+        <input type="text" formControlName="name" placeholder="Enter a name for this location" [readonly]="readonly(i)"/>
+        <!-- <app-field class="h-100" [valid]="!shouldValidate || !row.get('name').value || row.get('name').valid"
           errorMessage="Cannot exceed 250 characters" [showChevrons]="false" [isFullWidth]="true">
-          <input type="text" formControlName="name" placeholder="Enter a name for this location" [readonly]="!canEdit(i)"/>
-        </app-field>
+        </app-field> -->
       </td>
-      <td><input type="text" formControlName="street1" placeholder="Enter Address" [readonly]="!canEdit(i)"/></td>
-      <td><input type="text" formControlName="city" placeholder="Enter City" [readonly]="!canEdit(i)"/></td>
-      <td><input type="text" formControlName="postalCode" placeholder="Enter Postal Code" [readonly]="!canEdit(i)"/></td>
-      <td><button type="button" (click)="removeRow(i)" class="btn-clear" *ngIf="canEdit(i)"><i class="fa fa-trash" style="color: #ee220e"></i></button></td>
+      <td><input type="text" formControlName="street1" placeholder="Enter Address" [readonly]="readonly(i)"/></td>
+      <td><input type="text" formControlName="city" placeholder="Enter City" [readonly]="readonly(i)"/></td>
+      <td><input type="text" formControlName="postalCode" placeholder="Enter Postal Code" [readonly]="readonly(i)"/></td>
+      <td><button type="button" (click)="removeRow(i)" class="btn-clear" *ngIf="!readonly(i)"><i class="fa fa-trash" style="color: #ee220e"></i></button></td>
     </ng-container>
   </tr>
   <tr>
@@ -34,3 +34,11 @@
     <td></td>
   </tr>
 </table>
+<section class="error mt-3" *ngIf="showErrorSection">
+  <p *ngFor="let message of validationMessages">
+    <span class="app-cancel">
+      <mat-icon aria-label="error icon" style="font-size: 15px;">error</mat-icon>
+      {{message}}
+    </span>
+  </p>
+</section>

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
@@ -10,12 +10,7 @@
   <tr *ngFor="let row of rows.controls; let i=index" [ngClass]="{ 'text-grey': readonly(i) }">
     <ng-container [formGroup]="row">
       <td><span class="bold">{{ offsiteStorageStatus[row.value.status] }}</span></td>
-      <td>
-        <input type="text" formControlName="name" placeholder="Enter a name for this location" [readonly]="readonly(i)"/>
-        <!-- <app-field class="h-100" [valid]="!shouldValidate || !row.get('name').value || row.get('name').valid"
-          errorMessage="Cannot exceed 250 characters" [showChevrons]="false" [isFullWidth]="true">
-        </app-field> -->
-      </td>
+      <td><input type="text" formControlName="name" placeholder="Enter a name for this location" [readonly]="readonly(i)"/></td>
       <td><input type="text" formControlName="street1" placeholder="Enter Address" [readonly]="readonly(i)"/></td>
       <td><input type="text" formControlName="city" placeholder="Enter City" [readonly]="readonly(i)"/></td>
       <td><input type="text" formControlName="postalCode" placeholder="Enter Postal Code" [readonly]="readonly(i)"/></td>

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
@@ -6,18 +6,18 @@
     <th style="width: 200px">Postal Code</th>
     <th style="width: 45px"></th>
   </thead>
-  <tr *ngFor="let row of rows.controls; let i=index">
+  <tr *ngFor="let row of rows.controls; let i=index" [ngClass]="{ 'text-grey': !canEdit(i) }">
     <ng-container [formGroup]="row">
       <td><span class="bold">{{ offsiteStorageStatus[row.value.status] }}</span></td>
-      <td><input type="text" formControlName="street1" placeholder="Enter Address" [readonly]="!enabled"/></td>
-      <td><input type="text" formControlName="city" placeholder="Enter City" [readonly]="!enabled"/></td>
-      <td><input type="text" formControlName="postalCode" placeholder="Enter Postal Code" [readonly]="!enabled"/></td>
-      <td><button type="button" (click)="removeRow(i)" class="btn-clear" *ngIf="canRemove(i)"><i class="fa fa-trash" style="color: #ee220e"></i></button></td>
+      <td><input type="text" formControlName="street1" placeholder="Enter Address" [readonly]="!canEdit(i)"/></td>
+      <td><input type="text" formControlName="city" placeholder="Enter City" [readonly]="!canEdit(i)"/></td>
+      <td><input type="text" formControlName="postalCode" placeholder="Enter Postal Code" [readonly]="!canEdit(i)"/></td>
+      <td><button type="button" (click)="removeRow(i)" class="btn-clear" *ngIf="canEdit(i)"><i class="fa fa-trash" style="color: #ee220e"></i></button></td>
     </ng-container>
   </tr>
   <tr>
-    <td [colSpan]="2">
-      <button type="button" (click)="addRow()" class="btn-clear" style="height: 100%;" *ngIf="enabled">
+    <td [colSpan]="2" class="pt-3 text-left">
+      <button type="button" (click)="addRow()" class="btn btn-secondary" style="height: 100%;" *ngIf="enabled">
         <i class="fa fa-plus-circle" style="color: #1a5a96;"></i> Add Additional Storage
       </button>
     </td>

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
@@ -8,8 +8,7 @@
   </thead>
   <tr *ngFor="let row of rows.controls; let i=index">
     <ng-container [formGroup]="row">
-      <!-- <td>{{ OffsiteStorageStatusEnum[rows.at(i).get('status')] | uppercase }}</td> -->
-      <td><input type="text" formControlName="status" readonly /></td>
+      <td><span class="bold">{{ offsiteStorageStatus[row.value.status] }}</span></td>
       <td><input type="text" formControlName="street1" placeholder="Enter Address" [readonly]="!enabled"/></td>
       <td><input type="text" formControlName="city" placeholder="Enter City" [readonly]="!enabled"/></td>
       <td><input type="text" formControlName="postalCode" placeholder="Enter Postal Code" [readonly]="!enabled"/></td>

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.html
@@ -12,7 +12,7 @@
       <td><input type="text" formControlName="street1" placeholder="Enter Address" [readonly]="!enabled"/></td>
       <td><input type="text" formControlName="city" placeholder="Enter City" [readonly]="!enabled"/></td>
       <td><input type="text" formControlName="postalCode" placeholder="Enter Postal Code" [readonly]="!enabled"/></td>
-      <td><button type="button" (click)="removeRow(i)" class="btn-clear" *ngIf="enabled"><i class="fa fa-trash" style="color: #ee220e"></i></button></td>
+      <td><button type="button" (click)="removeRow(i)" class="btn-clear" *ngIf="canRemove(i)"><i class="fa fa-trash" style="color: #ee220e"></i></button></td>
     </ng-container>
   </tr>
   <tr>

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.scss
@@ -52,3 +52,7 @@ table {
     border: none;
   }
 }
+
+.bold {
+  font-weight: bold;
+}

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.scss
@@ -56,3 +56,7 @@ table {
 .bold {
   font-weight: bold;
 }
+
+.text-grey {
+  color: #999999;
+}

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.scss
@@ -1,3 +1,13 @@
+::ng-deep {
+  table.offsite-storage {
+    td {
+      .app-field {
+        margin-bottom: 0; // override default bottom margin when used in this table component
+      }
+    }
+  }
+}
+
 table {
   width: 100%;
 
@@ -16,8 +26,7 @@ table {
       background-color: white;
       text-align: center;
       border: 1px solid black;
-      height: 27px;
-      vertical-align: bottom;
+      height: 35px;
       &:last-of-type {
         background: none !important;
         border: none;

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
@@ -27,7 +27,7 @@ export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStora
   registerOnChange(fn: any) { this.onChange = fn; }
   registerOnTouched(fn: any) { this.onTouched = fn; }
 
-  OffsiteStorageStatusEnum = OffsiteStorageStatus;
+  offsiteStorageStatus = OffsiteStorageStatus;
 
   constructor(private fb: FormBuilder) {
     super();

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
@@ -22,7 +22,10 @@ import { BaseControlValueAccessor } from '../BaseControlValueAccessor';
   ]
 })
 export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStorage[]> {
+  // Whether this control is enabled or not (affects edit mode)
   @Input() enabled: boolean = true;
+  // Whether to run validation per row
+  @Input() shouldValidate: boolean = false;
   rows = new FormArray([]);
   registerOnChange(fn: any) { this.onChange = fn; }
   registerOnTouched(fn: any) { this.onTouched = fn; }
@@ -57,6 +60,7 @@ export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStora
   private addInternal(value: OffsiteStorage) {
     const group = this.fb.group({
       id: [value.id],
+      name: [value.name, [Validators.required, Validators.maxLength(250)]],
       street1: [value.street1, [Validators.required]],
       city: [value.city, [Validators.required]],
       province: ['BC', [Validators.required]],

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
@@ -70,7 +70,7 @@ export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStora
 
   addRow() {
     const newRow: OffsiteStorage = new OffsiteStorage();
-    newRow.status = OffsiteStorageStatus.Added;
+    newRow.status = OffsiteStorageStatus.Active;
     this.writeValue([...this.rows.value, newRow]);
   }
 
@@ -89,5 +89,9 @@ export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStora
       }
     }
     return isNotValid && { invalid: true };
+  }
+
+  canRemove(index: number): boolean {
+    return this.enabled && this.rows.at(index).get('status').value !== this.offsiteStorageStatus.Removed;
   }
 }

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, forwardRef } from '@angular/core';
-import { FormBuilder, FormArray, FormGroup, NG_VALUE_ACCESSOR, FormControl, NG_VALIDATORS, Validators } from '@angular/forms';
+import { FormBuilder, FormArray, FormGroup, NG_VALUE_ACCESSOR, FormControl, NG_VALIDATORS, Validators, AbstractControl } from '@angular/forms';
 import { OffsiteStorage, OffsiteStorageStatus } from '@models/offsite-storage.model';
 import { BaseControlValueAccessor } from '../BaseControlValueAccessor';
 
@@ -89,12 +89,25 @@ export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStora
 
   removeRow(index: number) {
     if (index >= 0 && index < this.rows.length) {
+      this.removeInternal(index);
+      this.writeValue(this.rows.value);
+    }
+  }
+
+  private removeInternal(index: number) {
+    const row = this.rows.at(index);
+    const obj = row.value as OffsiteStorage;
+
+    // Existing location - flag it as "removed" in Dynamics
+    if (obj.id) {
       const patchObj: Partial<OffsiteStorage> = {
         status: OffsiteStorageStatus.Removed,
         dateRemoved: new Date()
       };
-      this.rows.at(index).patchValue(patchObj);
-      this.writeValue(this.rows.value);
+      row.patchValue(patchObj);
+    } else {
+      // This location has never been submitted. We can safely remove the whole row client-side.
+      this.rows.removeAt(index);
     }
   }
 

--- a/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/tables/offsite-table/offsite-table.component.ts
@@ -31,7 +31,6 @@ export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStora
 
   constructor(private fb: FormBuilder) {
     super();
-
     this.rows.valueChanges.subscribe(val => {
       this.onChange(val);
       this.value = val;
@@ -62,7 +61,9 @@ export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStora
       city: [value.city, [Validators.required]],
       province: ['BC', [Validators.required]],
       postalCode: [value.postalCode, [Validators.required]],
-      status: [value.status]
+      status: [value.status],
+      dateAdded: [value.dateAdded],
+      dateRemoved: [value.dateRemoved]
     });
 
     this.rows.push(group);
@@ -71,12 +72,17 @@ export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStora
   addRow() {
     const newRow: OffsiteStorage = new OffsiteStorage();
     newRow.status = OffsiteStorageStatus.Active;
+    newRow.dateAdded = new Date();
     this.writeValue([...this.rows.value, newRow]);
   }
 
   removeRow(index: number) {
     if (index >= 0 && index < this.rows.length) {
-      this.rows.at(index).patchValue({ status: OffsiteStorageStatus.Removed });
+      const patchObj: Partial<OffsiteStorage> = {
+        status: OffsiteStorageStatus.Removed,
+        dateRemoved: new Date()
+      };
+      this.rows.at(index).patchValue(patchObj);
       this.writeValue(this.rows.value);
     }
   }
@@ -91,7 +97,7 @@ export class OffsiteTableComponent extends BaseControlValueAccessor<OffsiteStora
     return isNotValid && { invalid: true };
   }
 
-  canRemove(index: number): boolean {
+  canEdit(index: number): boolean {
     return this.enabled && this.rows.at(index).get('status').value !== this.offsiteStorageStatus.Removed;
   }
 }

--- a/cllc-public-app/ClientApp/src/app/models/offsite-storage.model.ts
+++ b/cllc-public-app/ClientApp/src/app/models/offsite-storage.model.ts
@@ -1,5 +1,5 @@
 export enum OffsiteStorageStatus {
-  Added = 1,
+  Active = 1,
   Removed = 845280000,
 }
 

--- a/cllc-public-app/ClientApp/src/app/models/offsite-storage.model.ts
+++ b/cllc-public-app/ClientApp/src/app/models/offsite-storage.model.ts
@@ -11,5 +11,7 @@ export class OffsiteStorage {
   city: string;
   province: string;
   postalCode: string;
-  status: OffsiteStorageStatus;
+  status?: OffsiteStorageStatus;
+  dateAdded?: Date;
+  dateRemoved?: Date;
 }

--- a/cllc-public-app/Controllers/LicensesController.cs
+++ b/cllc-public-app/Controllers/LicensesController.cs
@@ -246,10 +246,10 @@ namespace Gov.Lclb.Cllb.Public.Controllers
             var dynamicsOffsiteStorage = new MicrosoftDynamicsCRMadoxioOffsitestorage
             {
                 LicenceODataBind = licenceUri,
-                Statuscode = (int?)OffsiteStorageStatus.Added,
-                AdoxioDateadded = DateTimeOffset.Now,
+                Statuscode = (int?)OffsiteStorageStatus.Added
             };
             dynamicsOffsiteStorage.CopyValues(item);
+            dynamicsOffsiteStorage.AdoxioDateadded = DateTimeOffset.Now;
             _dynamicsClient.Offsitestorages.Create(dynamicsOffsiteStorage);
         }
 

--- a/cllc-public-app/Models.Extensions/OffsiteStorage.cs
+++ b/cllc-public-app/Models.Extensions/OffsiteStorage.cs
@@ -21,7 +21,9 @@ namespace Gov.Lclb.Cllb.Public.Models
                     Status = (OffsiteStorageStatus?)item.Statuscode,
                     Street1 = item.AdoxioStreet1,
                     City = item.AdoxioCity,
-                    PostalCode = item.AdoxioPostalcode
+                    PostalCode = item.AdoxioPostalcode,
+                    DateAdded = item.AdoxioDateadded,
+                    DateRemoved = item.AdoxioDateremoved
                 };
 
                 if (item.AdoxioOffsitestorageid != null)
@@ -44,6 +46,8 @@ namespace Gov.Lclb.Cllb.Public.Models
             to.AdoxioStreet1 = from.Street1;
             to.AdoxioCity = from.City;
             to.AdoxioPostalcode = from.PostalCode;
+            to.AdoxioDateadded = from.DateAdded;
+            to.AdoxioDateremoved = from.DateRemoved;
         }
     }
 }

--- a/cllc-public-app/ViewModels/OffsiteStorage.cs
+++ b/cllc-public-app/ViewModels/OffsiteStorage.cs
@@ -25,5 +25,7 @@ namespace Gov.Lclb.Cllb.Public.ViewModels
         public string Province { get; set; }
         public string PostalCode { get; set; }
         public OffsiteStorageStatus? Status { get; set; }
+        public DateTimeOffset? DateAdded { get; set; }
+        public DateTimeOffset? DateRemoved { get; set; }
     }
 }


### PR DESCRIPTION
**Changes:**
- populate Date Removed when a location is Removed 
- hide the trash can icon when a location is removed 
- show "Removed" and "Active" instead of their status codes 
- use the Name field to provide a name of the location; 
    - ensure the name cannot be longer than the field allows 
    - make it mandatory 
- not available if licence Type is Catering or UBrew/UVin

**Styling:**
- Make the `+ Add location` button use the secondary button style 
- Make the `Cancel` button use the secondary button style
- if an item is removed, show the font in a grey text 
- wrap the contents of the page at around 1000px 