### PR TITLE
LCSD-4779 Fix mailing address in account profile page

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.html
@@ -153,7 +153,7 @@
       <input class="form-control" type="text" formControlName="physicalAddressCity">
     </app-field>
     <section class="col-md-3 col-xs-12">
-      <app-field label="Province" [isFullWidth]="true">
+      <app-field label="Province" [isFullWidth]="true" [required]="true">
         <select class="form-control" formControlName="physicalAddressProvince">
           <option value="British Columbia">British Columbia</option>
           <option value="Ontario">Ontario</option>
@@ -180,9 +180,8 @@
         <input class="form-control" type="text" formControlName="physicalAddressPostalCode">
       </app-field>
     </section>
-    <app-field class="col-md-6 col-xs-12" [isFullWidth]="true" label="Country">
-
-      <input class="form-control" type="text" formControlName="physicalAddressCountry" value="Canada">
+    <app-field class="col-md-6 col-xs-12" [required]="true" [isFullWidth]="true" label="Country">
+      <input class="form-control" type="text" formControlName="physicalAddressCountry" value="Canada" readonly>
     </app-field>
   </div>
   <p></p>
@@ -212,8 +211,22 @@
         <app-field label="Province/State"
                    [valid]="form.get('businessProfile.mailingAddressProvince').valid || !form.get('businessProfile.mailingAddressProvince').touched"
                    [required]="true" [isFullWidth]="true">
-          <input type="text" formControlName="mailingAddressProvince" class="form-control">
-        </app-field>
+          <select class="form-control" formControlName="mailingAddressProvince">
+            <option value="British Columbia">British Columbia</option>
+            <option value="Ontario">Ontario</option>
+            <option value="Alberta">Alberta</option>
+            <option value="Quebec">Quebec</option>
+            <option value="Manitoba">Manitoba</option>
+            <option value="Nova Scotia">Nova Scotia</option>
+            <option value="New Brunswick">New Brunswick</option>
+            <option value="Newfoundland and Labrador">Newfoundland and Labrador</option>
+            <option value="Saskatchewan">Saskatchewan</option>
+            <option value="Prince Edward Island">Prince Edward Island</option>
+            <option value="Northwest Territories">Northwest Territories</option>
+            <option value="Yukon">Yukon</option>
+            <option value="Nunavut">Nunavut</option>
+          </select>
+          </app-field>
       </section>
       <section class="col-md-3 col-xs-12">
         <app-field label="Postal /Zip Code" errorMessage="This is required. The postal / zip code should be in one of the following formats: X1X1X1,
@@ -226,7 +239,7 @@
       <app-field class="col-md-6 col-xs-12" label="Country" errorMessage="Please enter country"
                  [valid]="form.get('businessProfile.mailingAddressCountry').valid || !form.get('businessProfile.mailingAddressCountry').touched"
                  [required]="true" [isFullWidth]="true">
-        <input type="text" formControlName="mailingAddressCountry" class="form-control">
+        <input type="text" formControlName="mailingAddressCountry" class="form-control" readonly>
       </app-field>
     </div>
   </div>

--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
@@ -143,13 +143,13 @@ export class AccountProfileComponent extends FormBase implements OnInit {
         physicalAddressStreet2: [""],
         physicalAddressCity: ["", Validators.required],
         physicalAddressPostalCode: ["", [Validators.required, this.customZipCodeValidator("physicalAddressCountry")]],
-        physicalAddressProvince: [{ value: "British Columbia" }],
-        physicalAddressCountry: [{ value: "Canada" }],
+        physicalAddressProvince: ["British Columbia", Validators.required],
+        physicalAddressCountry: ["Canada", Validators.required],
         mailingAddressStreet: ["", Validators.required],
         mailingAddressStreet2: [""],
         mailingAddressCity: ["", Validators.required],
         mailingAddressPostalCode: ["", [Validators.required, this.customZipCodeValidator("mailingAddressCountry")]],
-        mailingAddressProvince: ["", Validators.required],
+        mailingAddressProvince: ["British Columbia", Validators.required],
         mailingAddressCountry: ["Canada", Validators.required],
         websiteUrl: [""],
       }),
@@ -274,6 +274,8 @@ export class AccountProfileComponent extends FormBase implements OnInit {
         const businessProfile: Partial<Account> = { ...account };
         businessProfile.physicalAddressProvince = businessProfile.physicalAddressProvince || "British Columbia";
         businessProfile.physicalAddressCountry = "Canada";
+        businessProfile.mailingAddressProvince = businessProfile.mailingAddressProvince || "British Columbia";
+        businessProfile.mailingAddressCountry = "Canada";
 
         this.form.patchValue({
           businessProfile: businessProfile,


### PR DESCRIPTION
- Make country fields **read-only**
- Replace text input on mailing address province with drop down of Canadian provinces and territories