### PR TITLE
LCSD-4769 e-Notices Timestamps

### DIFF
--- a/cllc-interfaces/SharePoint/SharePointFileManager.cs
+++ b/cllc-interfaces/SharePoint/SharePointFileManager.cs
@@ -153,7 +153,7 @@ namespace Gov.Lclb.Cllb.Interfaces
             else
             // Scenario #3 - Using an API Gateway with Basic Authentication.  The API Gateway will handle other authentication and have different credentials, which may be NTLM
             {
-                // authenticate using the SSG.                
+                // authenticate using the SSG.
                 string credentials = Convert.ToBase64String(ASCIIEncoding.ASCII.GetBytes(sharePointSsgUsername + ":" + sharePointSsgPassword));
                 Authorization = "Basic " + credentials;
             }
@@ -218,6 +218,7 @@ namespace Gov.Lclb.Cllb.Interfaces
         {
             public string Name { get; set; }
             public string TimeLastModified { get; set; }
+            public string TimeCreated { get; set; }
             public string Length { get; set; }
             public string DocumentType { get; set; }
             public string ServerRelativeUrl { get; set; }
@@ -344,7 +345,7 @@ namespace Gov.Lclb.Cllb.Interfaces
         {
             string result = RemoveInvalidCharacters(filename);
 
-            // SharePoint requires that the filename is less than 128 characters.    
+            // SharePoint requires that the filename is less than 128 characters.
 
             if (result.Length >= maxLength)
             {
@@ -389,7 +390,7 @@ namespace Gov.Lclb.Cllb.Interfaces
 
             endpointRequest.Content = strContent;
 
-            // make the request.            
+            // make the request.
 
             var response = await _Client.SendAsync(endpointRequest);
             HttpStatusCode _statusCode = response.StatusCode;

--- a/cllc-public-app/ClientApp/src/app/components/notices/notices.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/notices/notices.component.ts
@@ -19,7 +19,7 @@ export class NoticesComponent extends FormBase implements OnInit {
   showValidationMessages = false;
 
   account: Account;
-  notices: FileSystemItem[]; // TODO: improve typing here
+  notices: FileSystemItem[];
 
   busy: Subscription;
   dataLoaded = false; // this is set to true when all page data is loaded

--- a/cllc-public-app/Controllers/FileController.cs
+++ b/cllc-public-app/Controllers/FileController.cs
@@ -125,7 +125,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
             var hasFileResult = _fileManagerClient.FileExists(fileExistsRequest);
 
             if (hasFileResult.ResultStatus == FileExistStatus.Exist)
-            // Update modifiedon to current time
+                // Update modifiedon to current time
                 hasFile = true;
             else
                 _logger.LogError($"Unexpected error - Unable to validate file - {logUrl}");
@@ -193,7 +193,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
         /// <returns>The file as binary data, or bad request if the request is invalid</returns>
         /// 
         [HttpGet("{entityId}/download-file/{entityName}/{fileName}")]
-        public async Task<IActionResult> DownloadAttachment(string entityId, string entityName, [FromQuery]string serverRelativeUrl, [FromQuery]string documentType)
+        public async Task<IActionResult> DownloadAttachment(string entityId, string entityName, [FromQuery] string serverRelativeUrl, [FromQuery] string documentType)
         {
             return await DownloadAttachmentInternal(entityId, entityName, serverRelativeUrl, documentType, true).ConfigureAwait(true);
         }
@@ -207,7 +207,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
         /// <param name="documentType"></param>
         /// <param name="checkUser"></param>
         /// <returns></returns>
-        private async Task<IActionResult> DownloadAttachmentInternal(string entityId, string entityName, [FromQuery]string serverRelativeUrl, [FromQuery]string documentType, bool checkUser)
+        private async Task<IActionResult> DownloadAttachmentInternal(string entityId, string entityName, [FromQuery] string serverRelativeUrl, [FromQuery] string documentType, bool checkUser)
         {
             // get the file.
             if (string.IsNullOrEmpty(serverRelativeUrl) || string.IsNullOrEmpty(documentType) || string.IsNullOrEmpty(entityId) || string.IsNullOrEmpty(entityName)) return BadRequest();
@@ -245,9 +245,9 @@ namespace Gov.Lclb.Cllb.Public.Controllers
 
         }
 
-        
 
-        
+
+
 
         /// <summary>
         ///  helper function used by the public file upload features to verify that the user has access.
@@ -304,7 +304,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
 
         [HttpGet("{token}/public-download-file/{entityName}/{fileName}")]
         [AllowAnonymous]
-        public async Task<IActionResult> PublicDownloadAttachment(string token, string entityName, [FromQuery]string serverRelativeUrl, [FromQuery]string documentType)
+        public async Task<IActionResult> PublicDownloadAttachment(string token, string entityName, [FromQuery] string serverRelativeUrl, [FromQuery] string documentType)
         {
             // decode the entityID
             var entityId = EncryptionUtility.DecryptStringHex(token, _encryptionKey);
@@ -349,7 +349,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
         [DisableRequestSizeLimit]
         [AllowAnonymous]
         public async Task<IActionResult> PublicUploadAttachment([FromRoute] string token, [FromRoute] string entityName,
-          [FromForm]IFormFile file, [FromForm] string documentType)
+          [FromForm] IFormFile file, [FromForm] string documentType)
         {
             // decode the entityID
             var entityId = EncryptionUtility.DecryptStringHex(token, _encryptionKey);
@@ -366,7 +366,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
         [DisableRequestSizeLimit]
         [AllowAnonymous]
         public async Task<IActionResult> PublicCovidApplication([FromRoute] string id,
-          [FromForm]IFormFile file, [FromForm] string documentType)
+          [FromForm] IFormFile file, [FromForm] string documentType)
         {
             var entityName = "application";
             // decode the entityID
@@ -536,7 +536,8 @@ namespace Gov.Lclb.Cllb.Public.Controllers
                                 // convert size from bytes (original) to KB
                                 size = fileDetails.Size,
                                 serverrelativeurl = fileDetails.ServerRelativeUrl,
-                                //timelastmodified = fileDetails.TimeLastModified.ToDateTime(),
+                                timecreated = fileDetails.TimeCreated.ToDateTime(),
+                                timelastmodified = fileDetails.TimeLastModified.ToDateTime(),
                                 documenttype = fileDetails.DocumentType
                             };
 
@@ -631,7 +632,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
         // allow large uploads
         [DisableRequestSizeLimit]
         public async Task<IActionResult> UploadAttachment([FromRoute] string entityId, [FromRoute] string entityName,
-            [FromForm]IFormFile file, [FromForm] string documentType)
+            [FromForm] IFormFile file, [FromForm] string documentType)
         {
             return await UploadAttachmentInternal(entityId, entityName, file, documentType, true).ConfigureAwait(true);
         }
@@ -648,7 +649,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
         private async Task<IActionResult> UploadAttachmentInternal(string entityId, string entityName,
             IFormFile file, string documentType, bool checkUser)
         {
-            FileSystemItem result = null;            
+            FileSystemItem result = null;
 
             if (string.IsNullOrEmpty(entityId) || string.IsNullOrEmpty(entityName) || string.IsNullOrEmpty(documentType)) return BadRequest();
 
@@ -668,8 +669,8 @@ namespace Gov.Lclb.Cllb.Public.Controllers
             fileName = illegalInFileName.Replace(fileName, "-");
 
             fileName = FileSystemItemExtensions.CombineNameDocumentType(fileName, documentType);
-            
-            var folderName = await _dynamicsClient.GetFolderName(entityName, entityId ).ConfigureAwait(true);
+
+            var folderName = await _dynamicsClient.GetFolderName(entityName, entityId).ConfigureAwait(true);
 
             _dynamicsClient.CreateEntitySharePointDocumentLocation(entityName, entityId, folderName, folderName);
 


### PR DESCRIPTION
This PR fixes the weird timestamps values we were seeing on the e-Notices page for the PDF files.
It now reflects the creation and last updated time from SharePoint (shown below)

![image](https://user-images.githubusercontent.com/24322224/107300650-ca4cc200-6a2e-11eb-916d-b8deaafae260.png)
