### PR TITLE
LCSD-5038 Deprecate worker qualification

### DIFF
--- a/cllc-public-app/ClientApp/src/app/app-routing.module.ts
+++ b/cllc-public-app/ClientApp/src/app/app-routing.module.ts
@@ -79,6 +79,7 @@ import { LicenseeRetailStoresComponent } from "./components/licensee-retail-stor
 import { TuaEventComponent } from "@components/tua-event/tua-event.component";
 import { ApplicationTiedHouseExemptionComponent } from "@components/applications/application-tied-house-exemption/application-tied-house-exemption.component";
 import { LiquorFreeEventComponent } from "@components/liquor-free-event/liquor-free-event.component";
+import { WorkerLandingPageComponent } from "@components/worker-qualification/worker-landing-page/worker-landing-page.component";
 
 const routes: Routes = [
   {
@@ -367,13 +368,22 @@ const routes: Routes = [
   },
   {
     path: "policy-document/worker-qualification-training",
-    component: WorkerHomeComponent,
+    component: WorkerLandingPageComponent,
     data: { slug: "worker-qualification-training" }
   },
   {
     path: "policy-document/worker-qualification-home",
-    component: WorkerHomeComponent,
+    component: WorkerLandingPageComponent,
     data: { slug: "worker-qualification-home" }
+  },
+  {
+    // Only show this policy document when the feature flag is enabled
+    path: "policy-document/worker-qualification-no-longer-required",
+    component: WorkerLandingPageComponent,
+    canActivate: [FeatureGuard],
+    data: {
+      feature: "DisableWorkerQualification",
+    }
   },
   {
     path: "policy-document/:slug",

--- a/cllc-public-app/ClientApp/src/app/app.module.ts
+++ b/cllc-public-app/ClientApp/src/app/app.module.ts
@@ -266,6 +266,7 @@ import { ResolvedApplicationsComponent } from './components/lg-approvals/resolve
 import { RelatedLicencePickerComponent } from './shared/components/related-licence-picker/related-licence-picker.component';
 import { ApplicationTiedHouseExemptionComponent } from './components/applications/application-tied-house-exemption/application-tied-house-exemption.component';
 import { LiquorFreeEventComponent } from "@components/liquor-free-event/liquor-free-event.component";
+import { WorkerLandingPageComponent } from "@components/worker-qualification/worker-landing-page/worker-landing-page.component";
 
 @NgModule({
   declarations: [
@@ -406,6 +407,7 @@ import { LiquorFreeEventComponent } from "@components/liquor-free-event/liquor-f
     RelatedLicencePickerComponent,
     ApplicationTiedHouseExemptionComponent,
     LiquorFreeEventComponent,
+    WorkerLandingPageComponent,
   ],
   imports: [
     AppRoutingModule,

--- a/cllc-public-app/ClientApp/src/app/components/policy-document/policy-document.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/policy-document/policy-document.component.ts
@@ -17,7 +17,10 @@ export class PolicyDocumentComponent implements OnInit {
   category: string;
   body: SafeHtml;
   @Input()
-  fullWidth: false;
+  fullWidth = false;
+  // Optional slug input. If supplied, it will take precedence over the route parameter.
+  @Input()
+  slug: string;
   @Output()
   slugChange = new EventEmitter<string>();
   dataLoaded: boolean;
@@ -34,16 +37,19 @@ export class PolicyDocumentComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.route.paramMap
-      .subscribe((data) => {
+    if (!!this.slug) {
+      this.setSlug(this.slug);
+    } else {
+      this.route.paramMap.subscribe((data) => {
         const slug = data.get("slug");
         if (slug) {
           this.setSlug(slug);
         }
       });
+    }
   }
 
-  setSlug(slug) {
+  setSlug(slug: string) {
     this.slugChange.emit(slug);
     this.busy = this.policyDocumentDataService.getPolicyDocument(slug)
       .toPromise()

--- a/cllc-public-app/ClientApp/src/app/components/worker-qualification/worker-home/worker-home.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/worker-qualification/worker-home/worker-home.component.ts
@@ -22,7 +22,7 @@ export class WorkerHomeComponent implements OnInit, AfterViewInit {
 
   constructor(public dialog: MatDialog, private route: ActivatedRoute, private ref: ChangeDetectorRef) {
     this.route.data.pipe(
-        filter(data => !!data && !!data.slug))
+      filter(data => !!data && !!data.slug))
       .subscribe((data: any) => {
         this.policySlug = data.slug;
       });

--- a/cllc-public-app/ClientApp/src/app/components/worker-qualification/worker-landing-page/worker-landing-page.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/worker-qualification/worker-landing-page/worker-landing-page.component.html
@@ -1,0 +1,3 @@
+<app-worker-home *ngIf="!(disableQualification$ | async)"></app-worker-home>
+
+<app-policy-document #policyDocs [slug]="policySlug" *ngIf="disableQualification$ | async"></app-policy-document>

--- a/cllc-public-app/ClientApp/src/app/components/worker-qualification/worker-landing-page/worker-landing-page.component.spec.ts
+++ b/cllc-public-app/ClientApp/src/app/components/worker-qualification/worker-landing-page/worker-landing-page.component.spec.ts
@@ -1,0 +1,28 @@
+/* tslint:disable:no-unused-variable */
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { DebugElement } from '@angular/core';
+
+import { WorkerLandingPageComponent } from './worker-landing-page.component';
+
+describe('WorkerLandingPageComponent', () => {
+  let component: WorkerLandingPageComponent;
+  let fixture: ComponentFixture<WorkerLandingPageComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ WorkerLandingPageComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WorkerLandingPageComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/cllc-public-app/ClientApp/src/app/components/worker-qualification/worker-landing-page/worker-landing-page.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/worker-qualification/worker-landing-page/worker-landing-page.component.ts
@@ -1,0 +1,21 @@
+import { Component, OnInit } from '@angular/core';
+import { FeatureFlagService } from '@services/feature-flag.service';
+
+@Component({
+  selector: 'app-worker-landing-page',
+  templateUrl: './worker-landing-page.component.html',
+  styleUrls: ['./worker-landing-page.component.scss']
+})
+export class WorkerLandingPageComponent implements OnInit {
+
+  // This Observable will track the FEATURE_DISABLE_WORKER_QUALIFICATION feature flag as sent by the API
+  disableQualification$ = this.featureFlagService.featureOn('DisableWorkerQualification');
+
+  policySlug = 'worker-qualification-no-longer-required';
+
+  constructor(private featureFlagService: FeatureFlagService) {
+  }
+
+  ngOnInit() {
+  }
+}

--- a/cllc-public-app/Controllers/FeaturesController.cs
+++ b/cllc-public-app/Controllers/FeaturesController.cs
@@ -36,7 +36,8 @@ namespace Gov.Lclb.Cllb.Public.Controllers
                 ("FEATURE_TUA_EVENTS", "TemporaryUseAreaEvents"),
                 ("FEATURE_ELIGIBILITY", "Eligibility"),
                 ("FEATURE_RLRS", "RLRS"), // used to switch to the RLRS and disable the RAS intake
-                ("FEATURE_LIQUOR_FREE_EVENTS", "LiquorFreeEvents") // All-ages Liquor-Free events for Liquor Primary and Liquor Primary Club
+                ("FEATURE_LIQUOR_FREE_EVENTS", "LiquorFreeEvents"), // All-ages Liquor-Free events for Liquor Primary and Liquor Primary Club
+                ("FEATURE_DISABLE_WORKER_QUALIFICATION", "DisableWorkerQualification")  // Removes worker qualification from the portal
             };
 
         public FeaturesController(IConfiguration configuration)


### PR DESCRIPTION
**Deprecate Worker Qualification**

"Disable Worker Qualification" Feature Flag

* If enabled, replace the unauthenticated link to a new policy page document for worker information. hide the existing worker qualification pages.
* If someone navigates to https://justice.gov.bc.ca/cannabislicensing/policy-document/worker-qualification-training, then redirect them to the new route

![image](https://user-images.githubusercontent.com/24322224/110720884-36544e80-81c4-11eb-88d0-b935faeace60.png)
