### PR TITLE
LCSD-5243 Show phone number in appropriate format

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/liquor-renewal/liquor-renewal.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/liquor-renewal/liquor-renewal.component.html
@@ -381,8 +381,7 @@
     <app-field label="Phone Number (main)" [required]="true"
                [valid]="form.get('contactPersonPhone').valid || !form.get('contactPersonPhone').touched"
                errorMessage="Please enter the business contact's 10-digit phone number">
-      <input class="form-control" style="width: 250px;" maxlength="10" autocomplete="tel"
-             (keydown)="rejectIfNotDigitOrBackSpace($event)" type="text"
+      <input class="form-control" style="width: 250px;" mask="(000) 000-0000" autocomplete="tel" type="text"
              formControlName="contactPersonPhone">
     </app-field>
 


### PR DESCRIPTION
It was showing the phone number as "2505555555" instead of "(250) 555-5555"

![renewal-phone](https://user-images.githubusercontent.com/24322224/112067952-2d4d7080-8b26-11eb-8bdd-ed01afbab55b.png)
