### PR TITLE
LCSD-5494 Make primary address read-only for BC Service login

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/servicecard-profile/servicecard-profile.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/servicecard-profile/servicecard-profile.component.html
@@ -42,17 +42,18 @@
               <app-field class="col-md-12 col-xs-12" label="Street Address" [required]="true"
                 errorMessage="Please enter the street address" [valid]="isValidOrNotTouched('contact.address1_line1')"
                 [isFullWidth]="true">
-                <input class="form-control" type="text" formControlName="address1_line1">
+                <input class="form-control" type="text" formControlName="address1_line1" [readonly]="isPrimaryAddressReadOnly">
               </app-field>
               <app-field class="col-md-4 col-xs-12" label="City" [isFullWidth]="true"
                 errorMessage="Please enter the city" [required]="true"
                 [valid]="isValidOrNotTouched('contact.address1_city')">
-                <input class="form-control" type="text" formControlName="address1_city">
+                <input class="form-control" type="text" formControlName="address1_city" [readonly]="isPrimaryAddressReadOnly">
               </app-field>
               <section class="col-md-4 col-xs-12">
                 <app-field label="Province/State" [isFullWidth]="true" errorMessage="Please enter the province"
                   [required]="true" [valid]="isValidOrNotTouched('contact.address1_stateorprovince')">
-                  <select class="form-control" formControlName="address1_stateorprovince">
+                  <input *ngIf="isPrimaryAddressReadOnly" class="form-control" type="text" formControlName="address1_stateorprovince" readonly>
+                  <select *ngIf="!isPrimaryAddressReadOnly" class="form-control" formControlName="address1_stateorprovince">
                     <option value="British Columbia">British Columbia</option>
                     <option value="Ontario">Ontario</option>
                     <option value="Alberta">Alberta</option>
@@ -73,13 +74,13 @@
                 <app-field label="Postal Code"
                   errorMessage="This is required. The postal code should be in one of the following formats: X1X1X1 (no spaces)"
                   [required]="true" [valid]="isValidOrNotTouched('contact.address1_postalcode')">
-                  <input class="form-control" type="text" formControlName="address1_postalcode">
+                  <input class="form-control" type="text" formControlName="address1_postalcode" [readonly]="isPrimaryAddressReadOnly">
                 </app-field>
               </section>
               <app-field class="col-md-4 col-xs-12" label="Country" [isFullWidth]="true"
                 errorMessage="Please enter Country" [required]="true"
                 [valid]="!form.get('contact.address1_country').touched || form.get('contact.address1_country').valid">
-                <input formControlName="address1_country" class="form-control" type="text" readonly>
+                <input formControlName="address1_country" class="form-control" type="text" value="Canada" readonly>
               </app-field>
             </address>
           </div>

--- a/cllc-public-app/ClientApp/src/app/components/servicecard-profile/servicecard-profile.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/servicecard-profile/servicecard-profile.component.ts
@@ -29,6 +29,7 @@ export class ServiceCardProfileComponent extends FormBase implements OnInit {
   showErrorSection = false;
   validationMessages: string[];
   currentUser: User;
+  isPrimaryAddressReadOnly = false;
 
   // account profile form
   form = this.fb.group({
@@ -82,8 +83,18 @@ export class ServiceCardProfileComponent extends FormBase implements OnInit {
     if (this.currentUser && this.currentUser.contactid) {
       this.contactDataService.getContact(this.currentUser.contactid)
         .subscribe(contact => {
-          this.form.patchValue({ contact: contact });
+          this.form.patchValue({
+            contact: { ...contact, address1_country: 'Canada' }
+          });
+          this.makePrimaryAddressReadOnly(contact);
         });
+    }
+  }
+
+  private makePrimaryAddressReadOnly(contact: Contact) {
+    const { address1_line1, address1_city, address1_postalcode, address1_stateorprovince, address1_country } = contact;
+    if (address1_line1 || address1_city || address1_postalcode || address1_stateorprovince) {
+      this.isPrimaryAddressReadOnly = true;
     }
   }
 


### PR DESCRIPTION
**Changes:**

- When user logs in via BC Service Card, the primary address is set to read-only as service card manages the address as per drivers licence.
- If primary address is empty, then it is made editable to allow for changes

![image](https://user-images.githubusercontent.com/24322224/116326494-6c9c5c00-a779-11eb-843e-9a28dbd8b69c.png)
