### PR TITLE
LCSD-6255

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/application-renewal/application-renewal.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application-renewal/application-renewal.component.ts
@@ -17,6 +17,7 @@ import { Application } from "@models/application.model";
 import { FormBase, ApplicationHTMLContent } from "@shared/form-base";
 import { Account } from "@models/account.model";
 import { ApplicationTypeNames, FormControlState } from "@models/application-type.model";
+import { LicenceTypeNames} from "@models/license-type.model";
 import { TiedHouseConnection } from "@models/tied-house-connection.model";
 import { TiedHouseConnectionsDataService } from "@services/tied-house-connections-data.service";
 import { EstablishmentWatchWordsService } from "@services/establishment-watch-words.service";
@@ -78,6 +79,7 @@ export class ApplicationRenewalComponent extends FormBase implements OnInit {
   htmlContent = {} as ApplicationHTMLContent;
   readonly UPLOAD_FILES_MODE = UPLOAD_FILES_MODE;
   ApplicationTypeNames = ApplicationTypeNames;
+  LicenceTypeNames = LicenceTypeNames;
   FormControlState = FormControlState;
   mode: string;
   account: Account;
@@ -110,7 +112,7 @@ export class ApplicationRenewalComponent extends FormBase implements OnInit {
 
 
   holder(): string {
-    if(this.application.assignedLicence.licenseType === 'Section 119 Authorization'){
+    if(this.application.assignedLicence.licenseType === LicenceTypeNames.S119){
       return "authorized retailer";
     } else {
     return "licensee";
@@ -118,7 +120,7 @@ export class ApplicationRenewalComponent extends FormBase implements OnInit {
   }
 
   typeOf(): string {
-    if(this.application.assignedLicence.licenseType === 'Section 119 Authorization'){
+    if(this.application.assignedLicence.licenseType === LicenceTypeNames.S119){
       return "authorization";
     } else {
     return "licence";
@@ -127,7 +129,7 @@ export class ApplicationRenewalComponent extends FormBase implements OnInit {
   }
 
   titleOf(): string {
-    if(this.application.assignedLicence.licenseType === 'Section 119 Authorization'){
+    if(this.application.assignedLicence.licenseType === LicenceTypeNames.S119){
       return "Section 119 Authorization";
     } else {
     return "Cannabis Retail Store Licence";

--- a/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.ts
@@ -4,6 +4,7 @@ import { MatSnackBar } from "@angular/material/snack-bar";
 import { LicenseDataService } from "@app/services/license-data.service";
 import { Router } from "@angular/router";
 import { ApplicationTypeNames } from "@models/application-type.model";
+import { LicenceTypeNames } from "@models/license-type.model";
 import { FormBase } from "@shared/form-base";
 import { takeWhile } from "rxjs/operators";
 import { ApplicationLicenseSummary } from "@models/application-license-summary.model";
@@ -221,7 +222,7 @@ export class LicenceRowComponent extends FormBase implements OnInit {
     const result = this.isActive(item) &&
       !item.transferRequested &&
       this.actionsVisible(item) &&
-      item.licenceTypeName !== "Section 119 Authorization" &&
+      item.licenceTypeName !== LicenceTypeNames.S119 &&
       item.licenceTypeName !== "Marketing";
     return result;
   }

--- a/cllc-public-app/ClientApp/src/app/components/licences/licences.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/licences/licences.component.ts
@@ -59,7 +59,7 @@ export class LicencesComponent extends FormBase implements OnInit {
     "Licensee Retail Store", "Transfer in Progress - Licensee Retail Store", "Operated - Licensee Retail Store",
     "Deemed - Licensee Retail Store",
     "UBrew and UVin", "Transfer in Progress - UBrew and UVin", "Operated - UBrew and UVin", "Deemed - UBrew and UVin",
-    "Section 119 Authorization"
+    "S119 CRS Authorization", "Transfer in Progress - S119 CRS Authorization"
   ];
 
   constructor(

--- a/cllc-public-app/ClientApp/src/app/models/license-type.model.ts
+++ b/cllc-public-app/ClientApp/src/app/models/license-type.model.ts
@@ -6,3 +6,8 @@ export class LicenseType {
   name: string;
   allowedActions: ApplicationType[];
 }
+
+export enum LicenceTypeNames {
+  S119 = "S119 CRS Authorization",
+  CRS = "Cannabis Retail Store Licence"
+}

--- a/cllc-public-app/ViewModels/LicenceTypeNames.cs
+++ b/cllc-public-app/ViewModels/LicenceTypeNames.cs
@@ -15,6 +15,6 @@ namespace Gov.Lclb.Cllb.Public.ViewModels
 
         public const string Agent = "Agent";
 
-        public const string Section119 = "Section 119 Authorization";
+        public const string Section119 = "S119 CRS Authorization";
     }
 }


### PR DESCRIPTION
*rename Section 119 Authorization Licence Type to S119 CRS Authorization
* Not required* Update Convert CRS to S119 Process to use new Licence Type
Update Cannabis Renewal application to use updated language
Update Supported licence types on licences.components.ts
Added configurable name in licenceTypeNames