### PR TITLE
Remove IsTimeZone validate

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/sep/sep-application/event/event.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/sep/sep-application/event/event.component.ts
@@ -272,8 +272,7 @@ export class EventComponent extends FormBase implements OnInit {
       serviceStartValue: ["9:00 AM", [Validators.required]],
       serviceEndValue: ["9:30 PM", [Validators.required]],
       liquorServiceHoursExtensionReason: [""],
-      disturbancePreventionMeasuresDetails: [""],
-      isPacificTZ:["",[Validators.required]]
+      disturbancePreventionMeasuresDetails: [""]   
     }, { validators: eventTimesValidator });
 
     eventDate = Object.assign(new SepSchedule(null), eventDate);


### PR DESCRIPTION
"IsPacificTimeZone" is a local available only, no data save to db. not need validate checking.