### PR TITLE
LCSD-7127: Fix for PDF generation issue.

### DIFF
--- a/cllc-public-app/Models.Extensions/License.cs
+++ b/cllc-public-app/Models.Extensions/License.cs
@@ -88,6 +88,20 @@ namespace Gov.Lclb.Cllb.Public.Models
         }
         private static HoursOfService GetHourService(int dayOfWeek, int? open, int? close)
         {
+            // Occasionally, the function will receive null for open and close, or will recieve the value 845280096. 
+            // This means the business is closed that day.
+            // We need to handle this as to not throw exceptions.
+            if (open == null || close == null || open == 845280096 || close == 845280096)
+            {
+                return new HoursOfService
+                {
+                    DayOfWeek = dayOfWeek,
+                    StartTimeHour = null,
+                    StartTimeMinute = null,
+                    EndTimeHour = null,
+                    EndTimeMinute = null
+                };
+            }
             var opening = StoreHoursUtility.ConvertOpenHoursToString(open);
             var openingList = opening.Split(':');
             var closing = StoreHoursUtility.ConvertOpenHoursToString(close);

--- a/cllc-public-app/Models.Extensions/License.cs
+++ b/cllc-public-app/Models.Extensions/License.cs
@@ -88,10 +88,8 @@ namespace Gov.Lclb.Cllb.Public.Models
         }
         private static HoursOfService GetHourService(int dayOfWeek, int? open, int? close)
         {
-            // Occasionally, the function will receive null for open and close, or will recieve the value 845280096. 
-            // This means the business is closed that day.
-            // We need to handle this as to not throw exceptions.
-            if (open == null || close == null || open == 845280096 || close == 845280096)
+            const dayClosedValue = 845280096;
+            if (open == null || close == null || open == dayClosedValue || close == dayClosedValue)
             {
                 return new HoursOfService
                 {


### PR DESCRIPTION
Fix for PDF generation issue. Cases such as "Closed" or empty values for hours in Dynamics were previously unhandled specifically for Endorsements, which led to failed PDF generation. Added catch to check if value of hours is equal to 845280096 (the Dynamics integer value of "Closed") or null. Verified that PDFs can be generated with correct hours.