### PR TITLE
LCSD-7153: Update GET to POST for /process_transaction.asp

### DIFF
--- a/cllc-interfaces/BCEP/BCEPService.cs
+++ b/cllc-interfaces/BCEP/BCEPService.cs
@@ -254,7 +254,7 @@ namespace Gov.Lclb.Cllb.Interfaces
             try
             {
                 // this is a status request to Bambora, and can be repeated multiple times
-                var request = new HttpRequestMessage(HttpMethod.Get, query_url);
+                var request = new HttpRequestMessage(HttpMethod.Post, query_url);
                 var response = await client.SendAsync(request);
                 if (response.IsSuccessStatusCode)
                 {


### PR DESCRIPTION
Ticket: https://jag.gov.bc.ca/jira/browse/LCSD-7153

Reason: BCEP PCIR has changed the /process_transaction.asp endpoint on their service from a GET to a POST request. Updating our API code to reflect this change. No other changes needed to implement PCIR besides updating the root URL of the request in OpenShift secrets.