### PR TITLE
LCSD-7153: PCIR Implementation

### DIFF
--- a/cllc-interfaces/BCEP/BCEPService.cs
+++ b/cllc-interfaces/BCEP/BCEPService.cs
@@ -19,9 +19,11 @@ namespace Gov.Lclb.Cllb.Interfaces
     public class BCEPService: IBCEPService
     {
         
-
-    private string bcep_pay_url;
+        private bool pcir_enabled;
+        private string bcep_pay_url;
+        private string bcep_pcir_pay_url;
         private readonly string bcep_verify_url;
+        private readonly string bcep_pcir_verify_url;
         private readonly string bcep_merchid;
         private readonly string bcep_alt_merchid;
         private readonly string bcep_sep_merchid;
@@ -62,8 +64,11 @@ namespace Gov.Lclb.Cllb.Interfaces
         {
 
             client = httpClient;
+            pcir_enabled = bool.Parse(configuration["PCIR_ENABLED"]);
             bcep_pay_url = configuration["BCEP_SERVICE_URL"];
+            bcep_pcir_pay_url = configuration["BCEP_PCIR_SERVICE_URL"];
             bcep_verify_url = configuration["BCEP_SERVICE_VERIFY_URL"];
+            bcep_pcir_verify_url = configuration["BCEP_PCIR_SERVICE_VERIFY_URL"];
 
             bcep_sep_pay_url = configuration["BCEP_SEP_SERVICE_URL"];
             bcep_sep_verify_url = configuration["BCEP_SEP_SERVICE_VERIFY_URL"];
@@ -71,6 +76,11 @@ namespace Gov.Lclb.Cllb.Interfaces
             if (string.IsNullOrEmpty(bcep_verify_url))
             {
                 bcep_verify_url = bcep_pay_url;
+            }
+
+            if (string.IsNullOrEmpty(bcep_pcir_verify_url))
+            {
+                bcep_pcir_verify_url = bcep_pcir_pay_url;
             }
 
             if (string.IsNullOrEmpty(bcep_sep_pay_url))
@@ -82,7 +92,6 @@ namespace Gov.Lclb.Cllb.Interfaces
             {
                 bcep_sep_verify_url = bcep_sep_pay_url;
             }
-
             bcep_merchid = configuration["BCEP_MERCHANT_ID"]; 
             bcep_alt_merchid = configuration["BCEP_ALTERNATE_MERCHANT_ID"];
             bcep_sep_merchid = configuration["BCEP_SEP_MERCHANT_ID"];
@@ -213,7 +222,14 @@ namespace Gov.Lclb.Cllb.Interfaces
             }
             else
             {
-                redirect = bcep_pay_url;
+                if (pcir_enabled)
+                {
+                    redirect = bcep_pcir_pay_url;
+                }
+                else
+                {
+                    redirect = bcep_pay_url;
+                }
             }
 
             redirect += BCEP_P_SCRIPT + "?" + paramString;
@@ -255,6 +271,13 @@ namespace Gov.Lclb.Cllb.Interfaces
             {
                 // this is a status request to Bambora, and can be repeated multiple times
                 var request = new HttpRequestMessage(HttpMethod.Get, query_url);
+
+                // PCIR service requires a POST request
+                if (pcir_enabled) 
+                {
+                    request = new HttpRequestMessage(HttpMethod.Post, query_url);
+                } 
+
                 var response = await client.SendAsync(request);
                 if (response.IsSuccessStatusCode)
                 {
@@ -324,7 +347,14 @@ namespace Gov.Lclb.Cllb.Interfaces
             }
             else
             {
-                query_url = bcep_verify_url;
+                if (pcir_enabled)
+                {
+                    query_url = bcep_pcir_verify_url;
+                }
+                else
+                {
+                    query_url = bcep_verify_url;
+                }
             }
 
             query_url += BCEP_Q_SCRIPT + "?" + paramString;

--- a/cllc-interfaces/BCEP/BCEPService.cs
+++ b/cllc-interfaces/BCEP/BCEPService.cs
@@ -19,9 +19,9 @@ namespace Gov.Lclb.Cllb.Interfaces
     public class BCEPService: IBCEPService
     {
         
-        private bool pcir_enabled;
-        private string bcep_pay_url;
-        private string bcep_pcir_pay_url;
+        private readonly bool pcir_enabled;
+        private readonly string bcep_pay_url;
+        private readonly string bcep_pcir_pay_url;
         private readonly string bcep_verify_url;
         private readonly string bcep_pcir_verify_url;
         private readonly string bcep_merchid;


### PR DESCRIPTION
Ticket: https://jag.gov.bc.ca/jira/browse/LCSD-7153

This pull request completes the PCIR work by enabling or disabling PCIR with a feature flag as a fallback in case the PCIR service fails. Three new environment variables will be added to our DEV, TEST, and PROD environments:
- PCIR_ENABLED: A true/false to enable or disable PCIR. Disabling PCIR causes the application to fall back to the old Bambora URL. Note that this is the only environment variable that needs to be changed in order to swap between PCIR and the old URL.
- BCEP_PCIR_SERVICE_URL: The base URL for the PCIR service
- BCEP_PCIR_SERVICE_VERIFY_URL: The base URL for the PCIR service - note that this will fall back to the value of BCEP_PCIR_SERVICE_URL in case this value is not defined. The values should be identical in OpenShift, and to be honest I'm not sure if this is required, but I wanted to follow the same pattern as the old system and independently define the service URL in case it is relevant / if it changes in the future.

Verified locally that I can hot-swap between PCIR and the old Bambora link by simply changing the value of PCIR_ENABLED