### PR TITLE
LCSD-7244: Remove outage banner for 2024-07-31 maintenance event

### DIFF
--- a/cllc-public-app/ClientApp/src/app/app.component.html
+++ b/cllc-public-app/ClientApp/src/app/app.component.html
@@ -38,17 +38,6 @@
       </div>
     </header>
 
-    <section>
-      <div style="background: red; color: #ffffff; padding-left: 25px; padding-right: 25px; font-weight: bold; text-align: center;">
-				<br>
-        There will be a scheduled system update on July 31, 2024 between 6 and 7 am PT. The liquor and cannabis licensing portal will not be available during that time.
-        <br>
-        We apologize for any inconvenience.
-				<br>
-				<br>
-			</div>
-		</section>
-
     <div *ngIf="showBceidTermsOfUse()">
       <main class="app-content">
         <app-bceid-confirmation (reloadUser)="reloadUser()" [currentUser]="currentUser"></app-bceid-confirmation>


### PR DESCRIPTION
Follow-up from #4222.

Now that the maintenance event for 2024-07-31 is now complete, the outage banner must now be removed as per requested by the business area in [LCSD-7244](https://jag.gov.bc.ca/jira/browse/LCSD-7244).