### PR TITLE
LCSD-7126 Portal changes for ORV demo

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.html
@@ -365,6 +365,21 @@
     </div>
   </section>
   <section class="submit-container" style="background-color: #F2F2F2; border: none; color: #000;">
+    <h2 style="color: #000">Online Retailer Verification:</h2>
+    <div class="submit-content">
+      <p>To obtain the Online Retailer Verification button to place on your Website(s), 
+        please select the "Generate ORV Code" button below.  Once you have the code, 
+        you will need to add it to your Website(s).  
+        Consult your development team to add the code to your Website(s).
+      </p>
+    </div>
+    <div style="display: flex; justify-content: center;">
+      <button class="btn btn-primary" color="primary" (click)="openBadgeTemplateDialog()">
+          <span class="compact-button">Generate ORV Code</span>
+      </button>
+    </div>
+  </section>
+  <section class="submit-container" style="background-color: #F2F2F2; border: none; color: #000;">
     <h2 style="color: #000">Collection Notice:</h2>
     <div class="submit-content">
       <p>
@@ -380,3 +395,13 @@
 </div>
 </div>
 </div>
+
+<!-- Modal HTML -->
+<ng-template #badgeTemplateDialog>
+  <h2 mat-dialog-title class="centered-title">Generate ORV Code</h2>
+  <p>Paste this code into your website to create your Online Retailer Verification button:</p>
+  <pre><code>{{generatedOrvCode}}</code></pre>
+  <div mat-dialog-actions class="center-actions">
+    <button mat-raised-button color="primary" (click)="onCopy()">Copy</button>
+  </div>
+</ng-template>

--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.scss
@@ -80,3 +80,20 @@ hr {
     }
   }
 }
+
+.compact-button {
+  display: block; 
+  line-height: 1.4; 
+  margin: 0;
+  padding-top: 2px;
+  padding-bottom: 2px; 
+}
+
+.centered-title {
+  text-align: center;
+}
+
+.center-actions {
+  display: flex;
+  justify-content: center;
+}

--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
@@ -1,5 +1,5 @@
 import { filter, map, catchError, takeWhile } from "rxjs/operators";
-import { Component, OnInit, ViewChild, Input, EventEmitter, Output } from "@angular/core";
+import { Component, OnInit, ViewChild, Input, TemplateRef, EventEmitter, Output } from "@angular/core";
 import { User } from "@models/user.model";
 import { ContactDataService } from "@services/contact-data.service";
 import { Contact } from "@models/contact.model";
@@ -24,6 +24,10 @@ import { UserDataService } from "@services/user-data.service";
 import { endOfToday } from "date-fns";
 import { ApplicationDataService } from "@services/application-data.service";
 import { ApplicationTypeNames } from "../../models/application-type.model";
+import { MatDialog } from "@angular/material/dialog";
+import { Clipboard } from '@angular/cdk/clipboard';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { generatedText } from "environments/environment";
 
 // See the Moment.js docs for the meaning of these formats:
 // https://momentjs.com/docs/#/displaying/format/
@@ -110,6 +114,9 @@ export class AccountProfileComponent extends FormBase implements OnInit {
   validationMessages: string[];
   renewalType: string;
 
+  @ViewChild('badgeTemplateDialog') badgeTemplateDialog: TemplateRef<any>;
+  generatedOrvCode = generatedText.verificationBadge;
+
   get contacts(): FormArray {
     return this.form.get("otherContacts") as FormArray;
   }
@@ -124,7 +131,10 @@ export class AccountProfileComponent extends FormBase implements OnInit {
     private fb: FormBuilder,
     private router: Router,
     private route: ActivatedRoute,
-    private tiedHouseService: TiedHouseConnectionsDataService
+    private tiedHouseService: TiedHouseConnectionsDataService,
+    private dialog: MatDialog, 
+    private clipboard: Clipboard,
+    private snackBar: MatSnackBar
   ) {
     super();
     this.route.paramMap.subscribe(params => {
@@ -345,6 +355,26 @@ export class AccountProfileComponent extends FormBase implements OnInit {
     } else {
       return this.save();
     }
+  }
+
+  openBadgeTemplateDialog() {
+    this.dialog.open(this.badgeTemplateDialog, {
+      disableClose: true,
+      autoFocus: true,
+      width: "auto",
+      height: "auto",
+      maxWidth: "500px",
+      maxHeight: "80vh",
+      panelClass: 'custom-dialog-container'
+    });
+  }
+
+  onCopy(): void {
+    this.clipboard.copy(this.generatedOrvCode);
+    this.snackBar.open('HTML copied to clipboard', null, {
+      duration: 2000,
+    });
+    this.dialog.closeAll();
   }
 
   save(): Observable<boolean> {

--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
@@ -27,7 +27,7 @@ import { ApplicationTypeNames } from "../../models/application-type.model";
 import { MatDialog } from "@angular/material/dialog";
 import { Clipboard } from '@angular/cdk/clipboard';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { generatedText } from "environments/environment";
+import { environment } from "environments/environment";
 
 // See the Moment.js docs for the meaning of these formats:
 // https://momentjs.com/docs/#/displaying/format/
@@ -115,7 +115,7 @@ export class AccountProfileComponent extends FormBase implements OnInit {
   renewalType: string;
 
   @ViewChild('badgeTemplateDialog') badgeTemplateDialog: TemplateRef<any>;
-  generatedOrvCode = generatedText.verificationBadge;
+  generatedOrvCode = environment.verificationBadge;
 
   get contacts(): FormArray {
     return this.form.get("otherContacts") as FormArray;

--- a/cllc-public-app/ClientApp/src/environments/environment.ts
+++ b/cllc-public-app/ClientApp/src/environments/environment.ts
@@ -6,5 +6,10 @@
 export const environment = {
   production: false,
   lite: false,
-  development: true
+  development: true,
+};
+
+// TODO: Remove this when proper configuration is in place
+export const generatedText = {
+  verificationBadge: `<a href="#" onclick="window.open('https://orgbook-app-b7aa30-dev.apps.silver.devops.gov.bc.ca/verify/BC123456', '_blank', 'width=800,height=600'); return false;">Validate</a>`
 };

--- a/cllc-public-app/ClientApp/src/environments/environment.ts
+++ b/cllc-public-app/ClientApp/src/environments/environment.ts
@@ -7,9 +7,6 @@ export const environment = {
   production: false,
   lite: false,
   development: true,
-};
-
-// TODO: Remove this when proper configuration is in place
-export const generatedText = {
-  verificationBadge: `<a href="#" onclick="window.open('https://orgbook-app-b7aa30-dev.apps.silver.devops.gov.bc.ca/verify/BC123456', '_blank', 'width=800,height=600'); return false;">Validate</a>`
+  // TODO: Remove this when proper configuration is in place
+  verificationBadge: `<a href="#" onclick="window.open('https://orgbook-app-b7aa30-dev.apps.silver.devops.gov.bc.ca/verify/BC123456', '_blank', 'width=800,height=600'); return false;">Verify Retailer</a>`
 };


### PR DESCRIPTION
This pull request includes primarily work completed by Ross to get the Online Retailer Verification (ORV) ready to demo. Added a new box with a modal where a user can copy html code to paste into their website to trigger online verification.

Important notes:
- Currently, this will always copy BC123456 for demo purposes. In the near future this will be changed to use the existing BC registration ID for the retailer.
- Currently, the template for the html code is hardcoded in environment.ts. I would recommend building a config service such that we could fetch our openshift secrets from the API as Angular doesn't natively support runtime environment variables.