### PR TITLE
LCSD-7329: Multiple File Uploads for Zoning and Valid Interest

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.html
@@ -2298,8 +2298,8 @@
               </p>
               <section>
                 <app-file-uploader *ngIf="applicationId" documentType="Valid Interest"
-                                   fileTypes="FILE MUST BE IN PDF FORMAT." [disableUploads]="isOpenedByLGForApproval || lGHasApproved()"
-                                   [enableFileDeletion]="!isOpenedByLGForApproval && !lGHasApproved()" [multipleFiles]="false"
+                                   fileTypes="FILES MUST BE IN PDF FORMAT." [disableUploads]="isOpenedByLGForApproval || lGHasApproved()"
+                                   [enableFileDeletion]="!isOpenedByLGForApproval && !lGHasApproved()" [multipleFiles]="true"
                                    entityName="application" [useDocumentTypeForName]="true"
                                    (numberOfUploadedFiles)="uploadedValidInterestDocuments = $event" [entityId]="applicationId"
                                    [uploadHeader]="'TO UPLOAD OWNERSHIP OR LEASE DOCUMENTS, DRAG FILES HERE OR'">

--- a/cllc-public-app/ClientApp/src/app/components/applications/application/tabs/proof-of-zoning/proof-of-zoning.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/tabs/proof-of-zoning/proof-of-zoning.component.html
@@ -63,8 +63,8 @@
       from your local government that the location is zoned appropriately to operate
       a {{application?.licenseType}} licence.
     </p>
-    <app-file-uploader *ngIf="application?.id" documentType="Zoning" fileTypes="FILE MUST BE IN PDF FORMAT."
-                       [multipleFiles]="false" entityName="application" [useDocumentTypeForName]="true"
+    <app-file-uploader *ngIf="application?.id" documentType="Zoning" fileTypes="FILES MUST BE IN PDF FORMAT."
+                       [multipleFiles]="true" entityName="application" [useDocumentTypeForName]="true"
                        (numberOfUploadedFiles)="uploadedZoningDocuments = $event" [entityId]="application?.id"
                        [uploadHeader]="'TO UPLOAD ZONING DOCUMENTS, DRAG FILES HERE OR'" #proofOfZoningDocs>
     </app-file-uploader>


### PR DESCRIPTION
Updated [multipleFiles] flag of app-file-uploader components to allow for multiple file uploads on Zoning and Proof of Valid Interest for both permanent and temporary relocations.

Screenshots:
![temporaryrelocation](https://github.com/user-attachments/assets/18f2cbc3-4c87-4f91-9aee-772cfb8b3235)
![Zoning](https://github.com/user-attachments/assets/46bd0782-9768-4676-9604-8fec262a7cdb)
