### PR TITLE
LCSD-7328: Conditionally Disable Temporary Relocation Application

### DIFF
--- a/cllc-public-app/ClientApp/src/app/app-routing.module.ts
+++ b/cllc-public-app/ClientApp/src/app/app-routing.module.ts
@@ -355,7 +355,7 @@ const routes: Routes = [
     canActivate: [BCeidAuthGuard]
   },
   {
-    path: "relocation-type/:applicationId",
+    path: "relocation-type/:licenceId",
     component: RelocationTypeComponent,
     canActivate: [BCeidAuthGuard],
   },

--- a/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.ts
@@ -404,7 +404,7 @@ export class LicenceRowComponent extends FormBase implements OnInit {
   */
   doAction(licence: ApplicationLicenseSummary, actionName: string) {
     if (actionName === ApplicationTypeNames.LRSTransferofLocation) {
-      this.router.navigateByUrl(`/relocation-type/${licence.licenseId}`, { state: { licence: JSON.stringify(licence) } });
+      this.router.navigateByUrl(`/relocation-type/${licence.licenseId}`);
       return;
     }
 

--- a/cllc-public-app/ClientApp/src/app/components/relocation-type/relocation-type.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/relocation-type/relocation-type.component.html
@@ -1,10 +1,26 @@
+<div [ngBusy]="busy"></div>
 <div class="form-wrapper" style="position: relative">
   <div class="row">
     <div class="col-lg-8 col-sm-12">
       <h1>Type of Relocation</h1>
-      <p>If you are planning on relocating your Licensee Retail Store (LRS), you will need approval before you change and move your establishment address.</p>
-      <p>You may apply to permanently relocate your store or temporarily relocate your store for a five-year period while significant alterations (e.g. renovation, reconstruction) are made to the original location.</p>
-      <p>Before you apply, <a href="https://www2.gov.bc.ca/gov/content/employment-business/business/liquor-regulation-licensing/liquor-licence-permits/amend-liquor-licence/relocate-a-liquor-licence/relocation-of-a-licensee-retail-store" target="_blank">learn more about relocating a Licensee Retail Store.</a></p>
+      <p>
+        If you are planning on relocating your Licensee Retail Store (LRS), you
+        will need approval before you change and move your establishment
+        address.
+      </p>
+      <p>
+        You may apply to permanently relocate your store or temporarily relocate
+        your store for a five-year period while significant alterations (e.g.
+        renovation, reconstruction) are made to the original location.
+      </p>
+      <p>
+        Before you apply,
+        <a
+          href="https://www2.gov.bc.ca/gov/content/employment-business/business/liquor-regulation-licensing/liquor-licence-permits/amend-liquor-licence/relocate-a-liquor-licence/relocation-of-a-licensee-retail-store"
+          target="_blank"
+          >learn more about relocating a Licensee Retail Store.</a
+        >
+      </p>
       <p>Relocation application fee: $330</p>
       <h3 class="blue-header">TYPE OF APPLICATION</h3>
       <div class="padded-section content-bottom" [formGroup]="form">
@@ -20,25 +36,46 @@
           />
           Permanent Relocation
           <br />
-          <input
-            type="radio"
-            [value]="temporaryRelocation"
-            formControlName="relocationType"
-            id="temporaryRelocation"
-          />
-          Temporary Relocation
+          <div *ngIf="isOperatingAtTemporaryLocation">
+            <input
+              type="radio"
+              matTooltip="You cannot apply for a temporary relocation if your establishment is currently operating from a temporary location."
+              disabled
+            />
+            Temporary Relocation
+          </div>
+          <div *ngIf="!isOperatingAtTemporaryLocation">
+            <input
+              type="radio"
+              [value]="temporaryRelocation"
+              formControlName="relocationType"
+              id="temporaryRelocation"
+            />
+            Temporary Relocation
+          </div>
         </section>
       </div>
       <br />
       <div class="row button-row">
         <div class="col-lg-8 d-flex justify-content-start">
           <button class="btn btn-link mr-4" routerLink="/licences">
-            <fa-icon [icon]="faArrowLeft"></fa-icon>Return to Licenses & Authorizations
+            <fa-icon [icon]="faArrowLeft"></fa-icon>Return to Licenses &
+            Authorizations
           </button>
-          <button color="primary" mat-raised-button class="save-cont" [disabled]="requestStarted" (click)="processApplication()">
+          <button
+            color="primary"
+            mat-raised-button
+            class="save-cont"
+            [disabled]="requestStarted"
+            (click)="processApplication()"
+          >
             CONTINUE TO APPLICATION
             <fa-icon [icon]="faChevronRight" class="mr-0 ml-2"></fa-icon>
-            <mat-progress-bar class="my-2" *ngIf="requestStarted " mode="indeterminate"></mat-progress-bar>
+            <mat-progress-bar
+              class="my-2"
+              *ngIf="requestStarted"
+              mode="indeterminate"
+            ></mat-progress-bar>
           </button>
         </div>
         <div class="col-lg-4 d-flex justify-content-end">

--- a/cllc-public-app/ClientApp/src/app/components/relocation-type/relocation-type.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/relocation-type/relocation-type.component.ts
@@ -53,7 +53,7 @@ export class RelocationTypeComponent extends FormBase implements OnInit {
     ngOnInit() {
         this.busy = this.licenceDataService.getAllCurrentLicenses().subscribe(data => {
             this.licence = data.find(lic => lic.licenseId === this.licenceId);
-            if (this.licence.temporaryRelocationStatus === TemporaryRelocationStatus.Yes) {
+            if (this.licence && this.licence.temporaryRelocationStatus === TemporaryRelocationStatus.Yes) {
                 this.isOperatingAtTemporaryLocation = true;
             }
         });

--- a/cllc-public-app/ClientApp/src/app/models/application-license-summary.model.ts
+++ b/cllc-public-app/ClientApp/src/app/models/application-license-summary.model.ts
@@ -75,6 +75,8 @@ export class ApplicationLicenseSummary {
   headerRowSpan: number;
   serviceAreas: ServiceArea[];
   offsiteStorageLocations: OffsiteStorage[];
+
+  temporaryRelocationStatus: number;
 }
 
 export interface LicenceActionApplication {

--- a/cllc-public-app/Models.Extensions/License.cs
+++ b/cllc-public-app/Models.Extensions/License.cs
@@ -268,6 +268,7 @@ namespace Gov.Lclb.Cllb.Public.Models
                 RepresentativeCanAttendEducationSessions = licence.AdoxioCanattendeducationsessions,
                 RepresentativeCanAttendComplianceMeetings = licence.AdoxioCanattendcompliancemeetings,
                 RepresentativeCanRepresentAtHearings = licence.AdoxioCanrepresentathearings,
+                TemporaryRelocationStatus = licence.AdoxioTrlstatus,
                 AutoRenewal = (licence.AdoxioAutorenewal == true)
             };
 

--- a/cllc-public-app/ViewModels/ApplicationLicenseSummary.cs
+++ b/cllc-public-app/ViewModels/ApplicationLicenseSummary.cs
@@ -41,6 +41,7 @@ namespace Gov.Lclb.Cllb.Public.ViewModels
         public string LicenseId { get; set; }
         public string ApplicationId { get; set; }
         public string ApplicationTypeName { get; set; }
+        public int? TemporaryRelocationStatus { get; set; }
 
         [JsonConverter(typeof(StringEnumConverter))]
         public ApplicationTypeCategory? ApplicationTypeCategory { get; set; }


### PR DESCRIPTION
Ticket: https://jag.gov.bc.ca/jira/browse/LCSD-7328

This pull request improves on the existing temporary relocation application process, no longer relying on route state parameters to get license information, and instead just fetches the license based on the URL params. This removes possibilities that the user could end up on this page with no license information and ensures it is always fetched when the user hits the URL. 

Additionally, this PR adds Temporary Relocation Status - a property from Dynamics indicating whether the licensee is operating from a temporary location - to the payload for licenses, allowing us to disable the temporary relocation button on the relocation type form if the licensee is already operating from a temporary location. I have included a tooltip when the user hovers on the disabled temporary relocation button with the text "You cannot apply for a temporary relocation if your establishment is currently operating from a temporary location." Subject to wording updates from business, but gives users an indication of why the button is disabled. I believe this is better than simply routing temporary location licensees to the permanent relocation form when they request relocation, as it provides some insight into the "why" of the process.

In this PR are some minor clean-ups of old comments and better formatting as well.