### PR TITLE
LCSD-7327: New Address, LG/IN, Police fields default to blank for LRS Transfer of Location

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
@@ -393,6 +393,20 @@ export class ApplicationComponent extends FormBase implements OnInit {
               }, {});
 
             this.form.patchValue(noNulls);
+
+            // LCSD-7327: If the application is a permanent or temporary LRS relocation, set new address, LG/IN, and police fields to empty
+            if (this.application.applicationType.name === ApplicationTypeNames.LRSTransferofLocation || this.application.applicationType.name === ApplicationTypeNames.LRSTemporaryRelocation) {
+              // New Address Fields
+              this.form.get('establishmentAddressStreet').patchValue('');
+              this.form.get('establishmentAddressCity').patchValue('');
+              this.form.get('establishmentAddressPostalCode').patchValue('');
+              this.form.get('establishmentParcelId').patchValue('');
+              // LG/IN field
+              this.form.get('indigenousNation').patchValue('');
+              // Police Field
+              this.form.get('policeJurisdiction').patchValue('');
+            }
+
             //LCSD-5764 get address from application if no assigned license
             if (this.application != null && this.application.assignedLicence == null) {
               if (this.application.establishmentAddressStreet != null) {


### PR DESCRIPTION
Ticket: https://jag.gov.bc.ca/jira/browse/LCSD-7327

This PR sets the following fields to blank if the application type is a temporary or permanent location transfer of a Licensee Retail Store:
- New Address Street
- New Address City
- New Address Postal Code
- New Address Parcel ID
- Local Government/Indigenous Nation
- Police Jurisdiction

Screenshots:
![lgin](https://github.com/user-attachments/assets/a13b9935-6e24-45f6-a608-a1995fa6f5d8)
![address](https://github.com/user-attachments/assets/ba8a2156-cf3c-43b5-a39b-b0f9cbf9f442)
