### PR TITLE
LCSD-7275: Disallow illegal characters in company name change

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/permanent-change-to-a-licensee/permanent-change-to-a-licensee.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/permanent-change-to-a-licensee/permanent-change-to-a-licensee.component.html
@@ -584,31 +584,15 @@
           and certificate number on the certificate of incorporation have not
           changed. The fee is 20 per licence.
         </p>
-        <div class="">
-
-          <span>
-            <strong>Current licensee or holding company name (in full):</strong>
-          </span>
-
-          <mat-form-field class="ml-1 mr-2">
-            <mat-label>Company Name</mat-label>
-            <input matInput type="text" formControlName="description2">
-            <button mat-button *ngIf="value" matSuffix mat-icon-button aria-label="Clear" (click)="value=''">
-              <mat-icon>close</mat-icon>
-            </button>
-          </mat-form-field>
-
-          <span>Name changed to (in full):</span>
-
-          <mat-form-field class="ml-1 mr-2">
-            <mat-label>New Company Name</mat-label>
-            <input matInput type="text" formControlName="description3">
-            <button mat-button *ngIf="value" matSuffix mat-icon-button aria-label="Clear" (click)="value=''">
-              <mat-icon>close</mat-icon>
-            </button>
-          </mat-form-field>
-
-        </div>
+        <app-field label="Current licensee or holding company">
+          <input placeholder="Company Name" class="form-control" style="width: 350px;" type="text"
+            formControlName="description2" id="description2">
+        </app-field>
+        <app-field label="Name changed to (in full)" [valid]=" !showValidationMessages || form.get('description3').valid" 
+          errorMessage="The following characters are not allowed in a Company Name: ~ # % & * { } \ : < > ? / + | &quot;">
+          <input placeholder="New Copmany Name" class="form-control" style="width: 350px;" type="text"
+            formControlName="description3" id="description3">
+        </app-field>
         <h4>
           Copy of the Certificate of Change of Name Form from BC Registrar of Companies
         </h4>

--- a/cllc-public-app/ClientApp/src/app/components/applications/permanent-change-to-a-licensee/permanent-change-to-a-licensee.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/permanent-change-to-a-licensee/permanent-change-to-a-licensee.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, ViewChild } from "@angular/core";
-import { FormBuilder, FormGroup } from "@angular/forms";
+import { FormBuilder, FormGroup, Validators } from "@angular/forms";
 import { MatSnackBar } from "@angular/material/snack-bar";
 import { ActivatedRoute, Router } from "@angular/router";
 import { AppState } from "@app/app-state/models/app-state";
@@ -16,6 +16,7 @@ import { ContactComponent, ContactData } from "@shared/components/contact/contac
 import { faIdCard } from "@fortawesome/free-regular-svg-icons";
 import { faQuestionCircle } from "@fortawesome/free-solid-svg-icons";
 
+export const SharepointNameRegex = /^[^~#%&*{}\\:<>?/+|""]*$/;
 @Component({
   selector: "app-permanent-change-to-a-licensee",
   templateUrl: "./permanent-change-to-a-licensee.component.html",
@@ -114,7 +115,7 @@ export class PermanentChangeToALicenseeComponent extends FormBase implements OnI
       lastNameOld: [""],
       lastNameNew: [""],
       description2: [""],
-      description3: [""],
+      description3: ["", Validators.pattern(SharepointNameRegex)],
       authorizedToSubmit: ["", [this.customRequiredCheckboxValidator()]],
       signatureAgreement: ["", [this.customRequiredCheckboxValidator()]],
     });
@@ -171,7 +172,6 @@ export class PermanentChangeToALicenseeComponent extends FormBase implements OnI
         this.appContactDisabled = true;
       }
       this.form.patchValue(application);
-     
       this.dataLoaded = true;
     }
   }
@@ -345,11 +345,11 @@ export class PermanentChangeToALicenseeComponent extends FormBase implements OnI
         }));
   }
 
-  showLiquorCostColumn(item: any){
+  showLiquorCostColumn(item: any) {
     //const show = this.form.get(item.formControlName).value === true
     const show = true
-    && (item.name !== 'Internal Transfer of Shares')
-    && !(item.name === 'Change of Directors or Officers' && this.account.businessType  === 'PrivateCorporation');
+      && (item.name !== 'Internal Transfer of Shares')
+      && !(item.name === 'Change of Directors or Officers' && this.account.businessType === 'PrivateCorporation');
     return show;
   }
 
@@ -362,7 +362,8 @@ export class PermanentChangeToALicenseeComponent extends FormBase implements OnI
       contactPersonFirstName: "Please enter the business contact's first name",
       contactPersonLastName: "Please enter the business contact's last name",
       contactPersonPhone: "Please enter the business contact's 10-digit phone number",
-      contactPersonRole: "Please enter the contact person role"
+      contactPersonRole: "Please enter the contact person role",
+      description3: "The following characters are not allowed in a Company Name: ~ # % & * { } \\ : < > ? / + | \"",
     };
     return errorMap;
   }
@@ -404,7 +405,7 @@ const masterChangeList = [
   {
     name: "Change of Directors or Officers",
     formControlName: "csChangeOfDirectorsOrOfficers",
-    availableTo: ["PrivateCorporation", "PublicCorporation", "Society", "Coop", "MilitaryMess","LocalGovernment", "University"],
+    availableTo: ["PrivateCorporation", "PublicCorporation", "Society", "Coop", "MilitaryMess", "LocalGovernment", "University"],
     CannabisFee: 500,
     LiquorFee: 220,
     RequiresPHS: false,
@@ -419,7 +420,7 @@ const masterChangeList = [
     name: "Name Change, Licensee -- Corporation",
     otherName: "Name Change, Licensee -- Organization",
     formControlName: "csNameChangeLicenseeCorporation",
-    availableTo: ["PrivateCorporation", "PublicCorporation", "SoleProprietorship", "Coop", "MilitaryMess","University"],
+    availableTo: ["PrivateCorporation", "PublicCorporation", "SoleProprietorship", "Coop", "MilitaryMess", "University"],
     CannabisFee: 220,
     LiquorFee: 220,
     RequiresPHS: false,


### PR DESCRIPTION
Ticket: https://jag.gov.bc.ca/jira/browse/LCSD-7275

Disallow illegal characters that cause issues with Sharepoint file/folder creation in company name change. Can be applied to other types of name changes (Person first/last name, addition of executor / receiver), but does not seem necessary as these characters very rarely appear in legal names of people. 