### PR TITLE
LCSD-7328-Patch: Fix issue with processing relocation for LRS

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/licences/licence-row/licence-row.component.ts
@@ -404,7 +404,7 @@ export class LicenceRowComponent extends FormBase implements OnInit {
   */
   doAction(licence: ApplicationLicenseSummary, actionName: string) {
     if (actionName === ApplicationTypeNames.LRSTransferofLocation) {
-      this.router.navigateByUrl(`/relocation-type/${licence.licenseId}`);
+      this.router.navigateByUrl(`/relocation-type/${licence.licenseId}`, { state: { licence: JSON.stringify(licence) } });
       return;
     }
 


### PR DESCRIPTION
Fixed an issue where the license object was missing specific required properties added in by the licenses and authorizations page. Opportunity for future improvement here - make these properties intrinsic to the license object on the backend so we don't have to process things in front-end components. 

Quick fix for now, reverting to old style of URL parameter passing to reduce amount of duplicate code. Added additional safeguard to navigate the user back to the licenses and authorizations page if no license object is present in the router state. This happens when a user refreshes on the relocation type page.

Added a couple more comments as well.