### PR TITLE
LCSD-7355: Revert permanent change to licensee notice

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/permanent-change-to-a-licensee/permanent-change-to-a-licensee.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/permanent-change-to-a-licensee/permanent-change-to-a-licensee.component.html
@@ -494,7 +494,7 @@
         <p>Provide the updated Notice of Articles for your corporation. Alternatively, you can provide list of all
           current directors/officers by full legal name, position and date of appointment.</p>
         <p *ngIf="hasLiquor"><strong>For Liquor Licensees: Directors and Officers are required to submit a 
-          Personal History Summary Form for liquor-related applications.</strong></p>
+          Personal History Summary Form for liquor-related applications, except for <u>private corporations</u>.</strong></p>
         <app-file-uploader *ngIf="application?.id" documentType="NOA" fileTypes="FILE MUST BE IN PDF FORMAT."
           [multipleFiles]="true" entityName="application" [extensions]="['pdf']"
           (numberOfUploadedFiles)="uploadedNOA = $event" [entityId]="application.id"


### PR DESCRIPTION
Reverting change from business feedback to permanent-change-to-a-licensee.component.html. Component now displays the text that displayed before the changes were made.
![revert](https://github.com/user-attachments/assets/62cafc40-fc1b-4bdc-ac8f-5da21193a018)
