### PR TITLE
LCSD-7328-Temp-Relo-Changes: Update criteria for disabling temp relo

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/relocation-type/relocation-type.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/relocation-type/relocation-type.component.html
@@ -36,15 +36,15 @@
           />
           Permanent Relocation
           <br />
-          <div *ngIf="isOperatingAtTemporaryLocation">
+          <div *ngIf="isOperatingAtTemporaryLocation || temporaryRelocationApplicationExists">
             <input
               type="radio"
-              matTooltip="You cannot apply for a temporary relocation if your establishment is currently operating from a temporary location."
+              matTooltip="You cannot apply for a temporary relocation if your establishment is currently operating from a temporary location or you have an existing temporary relocation application in progress."
               disabled
             />
             Temporary Relocation
           </div>
-          <div *ngIf="!isOperatingAtTemporaryLocation">
+          <div *ngIf="!isOperatingAtTemporaryLocation && !temporaryRelocationApplicationExists">
             <input
               type="radio"
               [value]="temporaryRelocation"

--- a/cllc-public-app/ClientApp/src/app/components/relocation-type/relocation-type.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/relocation-type/relocation-type.component.ts
@@ -30,6 +30,7 @@ export class RelocationTypeComponent extends FormBase implements OnInit {
     temporaryRelocation = this.ApplicationTypeNames.LRSTemporaryRelocation;
     permanentRelocation = this.ApplicationTypeNames.LRSTransferofLocation;
     isOperatingAtTemporaryLocation: boolean = false;
+    temporaryRelocationApplicationExists: boolean = false;
 
     // Icons
     faTrash = faTrash;
@@ -56,6 +57,24 @@ export class RelocationTypeComponent extends FormBase implements OnInit {
             if (this.licence && this.licence.temporaryRelocationStatus === TemporaryRelocationStatus.Yes) {
                 this.isOperatingAtTemporaryLocation = true;
             }
+            this.licence.actionApplications.forEach(app => {
+                console.log("app: ", app);
+                if (app.applicationTypeName === this.ApplicationTypeNames.LRSTemporaryRelocation) {
+                    if (
+                        app.applicationStatus === ApplicationStatuses.Submitted ||
+                        app.applicationStatus === ApplicationStatuses.Incomplete ||
+                        app.applicationStatus === ApplicationStatuses.PendingApproval ||
+                        app.applicationStatus === ApplicationStatuses.Review ||
+                        app.applicationStatus === ApplicationStatuses.Assessment ||
+                        app.applicationStatus === ApplicationStatuses.Issued ||
+                        app.applicationStatus === ApplicationStatuses.PendingFinalInspection ||
+                        app.applicationStatus === ApplicationStatuses.ReviewingResults ||
+                        app.applicationStatus === ApplicationStatuses.PendingLicenseFee
+                    ) {
+                        this.temporaryRelocationApplicationExists = true;
+                    }
+                }
+            });
         } else {
             // Handle the case where the licence is not available in the router state (page refresh)
             console.error('Licence object not found in the router state.');


### PR DESCRIPTION
Updates per comments on https://jag.gov.bc.ca/jira/browse/LCSD-7328
Temporary relocation applications will now be disabled if:
1. The licensee is currently operating from a temporary location, or
2. The license has an existing application for a temporary relocation with one of the following statuses:
- Submitted
- Incomplete/Info Req
- Pending LG/IN Approval
- Under Review
- Application Assessment
- AIP Issued
- Pending Final Inspection
- Reviewing Inspection Results
- Pending Licence Fee
If the license has a Temporary Relocation Application with the status is Approved, the licensee will be able to submit another temporary relocation application so long as they are not currently operating from a temporary location.