### PR TITLE
LCSD-7483: Add banner for dynamics upgrade

### DIFF
--- a/cllc-public-app/ClientApp/src/app/app.component.html
+++ b/cllc-public-app/ClientApp/src/app/app.component.html
@@ -38,6 +38,17 @@
       </div>
     </header>
 
+    <section>
+      <div style="background: red; color: #ffffff; padding-left: 25px; padding-right: 25px; font-weight: bold; text-align: center;">
+				<br>
+        There will be a scheduled system maintenance starting on November 15, 2024 at 6 PM and ending on November 18, 2024 at 8 PM PT. The liquor and cannabis licensing portal will not be available during this time.
+        <br>
+        We apologize for any inconvenience.
+				<br>
+				<br>
+			</div>
+		</section>
+
     <div *ngIf="showBceidTermsOfUse()">
       <main class="app-content">
         <app-bceid-confirmation (reloadUser)="reloadUser()" [currentUser]="currentUser"></app-bceid-confirmation>


### PR DESCRIPTION
Added a banner for the upcoming dynamics upgrade.

Banner Text: "There will be a scheduled system maintenance starting on November 15, 2024 at 6 PM and ending on November 18, 2024 at 8 PM PT. The liquor and cannabis licensing portal will not be available during this time. We apologize for any inconvenience."

![385408222-efdcad1c-3bfb-4581-81f8-043a9dd61f9a](https://github.com/user-attachments/assets/ec83ce85-d718-418b-b923-7a2137d4b82c)
