### PR TITLE
LCSD-7414: Added refund policy for renewal applications

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/application-renewal/application-renewal.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application-renewal/application-renewal.component.html
@@ -470,6 +470,39 @@
   </app-field>
 </address>
 
+<h3 class="blue-header">REFUND POLICYY</h3>
+<div class="content-bottom">
+  <p>
+    Licence renewal fees are generally non-refundable.
+    <br><br>
+    Refunds for <a href="https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/241_2016#Schedule1" target="_blank">licence renewal fees</a> may be available if the:
+  </p>
+  <ul>
+    <li>The LCRB has made an error</li>
+    <li>Applicant has overpaid</li>
+  </ul>
+  <p>
+    Renewal fees must be paid in full for a licence to remain valid.
+  </p>
+  <p>
+    Payment may appear on a credit card statement as:<br>
+    "Liquor and Cannabis Re… Victoria BC" and other variations.
+  </p>
+  <p>
+    The LCRB investigates all credit card chargeback requests for fees and will dispute chargeback requests. A note will also be made on your LCRB account and there may be consequences for fraudulent requests.
+  </p>
+
+  <app-field [valid]="!showValidationMessages || form.get('readRefundPolicy').valid"
+             errorMessage="Please affirm that you have read and understand the refund policy." [showChevrons]="false">
+    <mat-checkbox formControlName="readRefundPolicy">
+      <span class="error-states">*</span>
+      <span class="ml-2">
+        I have read and understand the refund policy.
+      </span>
+    </mat-checkbox>
+  </app-field>
+</div>
+
 <h3 class="blue-header ngtest-declarations">
   DECLARATIONS
 </h3>

--- a/cllc-public-app/ClientApp/src/app/components/applications/application-renewal/application-renewal.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application-renewal/application-renewal.component.ts
@@ -52,6 +52,7 @@ const ValidationErrorMap = {
   contactPersonPhone: "Please enter the business contact's 10-digit phone number",
   authorizedToSubmit: "Please affirm that you are authorized to submit the application",
   signatureAgreement: "Please affirm that all of the information provided for this application is true and complete",
+  readRefundPolicy: "Please affirm that you have read and understand the refund policy"
 };
 
 
@@ -242,6 +243,7 @@ export class ApplicationRenewalComponent extends FormBase implements OnInit {
     
           authorizedToSubmit: ["", [this.customRequiredCheckboxValidator()]],
           signatureAgreement: ["", [this.customRequiredCheckboxValidator()]],
+          readRefundPolicy: ["", [this.customRequiredCheckboxValidator()]],
     
           assignedLicence: this.fb.group({
             id: [""],

--- a/cllc-public-app/ClientApp/src/app/components/applications/liquor-renewal/liquor-renewal.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/liquor-renewal/liquor-renewal.component.html
@@ -396,6 +396,39 @@
   </address>
 </div>
 
+<h3 class="blue-header">REFUND POLICYY</h3>
+<div class="content-bottom">
+  <p>
+    Licence renewal fees are generally non-refundable.
+    <br><br>
+    Refunds for <a href="https://www.bclaws.gov.bc.ca/civix/document/id/complete/statreg/241_2016#Schedule1" target="_blank">licence renewal fees</a> may be available if the:
+  </p>
+  <ul>
+    <li>The LCRB has made an error</li>
+    <li>Applicant has overpaid</li>
+  </ul>
+  <p>
+    Renewal fees must be paid in full for a licence to remain valid.
+  </p>
+  <p>
+    Payment may appear on a credit card statement as:<br>
+    "Liquor and Cannabis Re… Victoria BC" and other variations.
+  </p>
+  <p>
+    The LCRB investigates all credit card chargeback requests for fees and will dispute chargeback requests. A note will also be made on your LCRB account and there may be consequences for fraudulent requests.
+  </p>
+
+  <app-field [valid]="!showValidationMessages || form.get('readRefundPolicy').valid"
+             errorMessage="Please affirm that you have read and understand the refund policy." [showChevrons]="false">
+    <mat-checkbox formControlName="readRefundPolicy">
+      <span class="error-states">*</span>
+      <span class="ml-2">
+        I have read and understand the refund policy.
+      </span>
+    </mat-checkbox>
+  </app-field>
+</div>
+
 <h3 class="blue-header ngtest-declarations">
   DECLARATIONS
 </h3>

--- a/cllc-public-app/ClientApp/src/app/components/applications/liquor-renewal/liquor-renewal.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/liquor-renewal/liquor-renewal.component.ts
@@ -44,6 +44,7 @@ const ValidationErrorMap = {
   contactPersonPhone: "Please enter the business contact's 10-digit phone number",
   authorizedToSubmit: "Please affirm that you are authorized to submit the application",
   signatureAgreement: "Please affirm that all of the information provided for this application is true and complete",
+  readRefundPolicy: "Please affirm that you have read and understand the refund policy",
 
   ldbOrderTotals: "Please provide LDB Order Totals ($0 - $10,000,000)",
   ldbOrderTotalsConfirm: "Please confirm LDB Order Totals matches",
@@ -142,7 +143,9 @@ export class LiquorRenewalComponent extends FormBase implements OnInit {
 
       authorizedToSubmit: ["", [this.customRequiredCheckboxValidator()]],
       signatureAgreement: ["", [this.customRequiredCheckboxValidator()]],
-      isManufacturedMinimum: ["", []]
+      isManufacturedMinimum: ["", []],
+
+      readRefundPolicy: ["", [this.customRequiredCheckboxValidator()]],
     });
 
     this.previousYear = (new Date().getFullYear() - 1).toString();


### PR DESCRIPTION
This change adds a new 'Refund Policy' section for Liquor and Cannabis renewal applications as mentioned in https://jag.gov.bc.ca/jira/browse/LCSD-7414

The new checkbox is part of the validation so that the applicants are required to read and affirm the refund policy. 

![image](https://github.com/user-attachments/assets/16d735d5-01d8-4b25-b629-72c44b161f1b)
