### PR TITLE
LCSD-7382: Reverted logic for Establishment Hours of Sale

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.html
@@ -2150,6 +2150,127 @@
 
           </div>
 
+          <!-- Hours of Sale -->
+          <section class="ngtest-hours-of-sale" *ngIf="application?.applicationType?.showHoursOfSale">
+            <h3 class="blue-header">HOURS OF SALE</h3>
+            <div class="padded-section content-bottom">
+              <p *ngIf="application?.applicationType?.name === ApplicationTypeNames.FP || application?.applicationType?.name === ApplicationTypeNames.FPRelo">
+                The standard service hours for a Food Primary are between 9:00AM and midnight. You may extend these hours by
+                submitting an Extend Hours of Service Beyond Standard Service Hours application from the application dashboard after
+                you submit your Food Primary application. LG/IN approval is required.
+              </p>
+              <p *ngIf="application?.applicationType?.name !== ApplicationTypeNames.FP && application?.applicationType?.name !== ApplicationTypeNames.FPRelo">
+                Indicate the
+                proposed hours of sales below.
+              </p>
+              <table class="store-hours">
+                <tr>
+                  <th class="lead"></th>
+                  <th>Sunday</th>
+                  <th>Monday</th>
+                  <th>Tuesday</th>
+                  <th>Wednesday</th>
+                  <th>Thursday</th>
+                  <th>Friday</th>
+                  <th>Saturday</th>
+                </tr>
+                <tr>
+                  <th>Open</th>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursSundayOpen">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursMondayOpen">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursTuesdayOpen">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursWednesdayOpen">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursThursdayOpen">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursFridayOpen">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursSaturdayOpen">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                </tr>
+                <tr>
+                  <th>Close</th>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursSundayClose">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursMondayClose">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursTuesdayClose">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursWednesdayClose">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursThursdayClose">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursFridayClose">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                  <td>
+                    <select class="form-control" formControlName="serviceHoursSaturdayClose">
+                      <option value=""> -- </option>
+                      <option *ngFor="let item of ServiceHours" [value]="item">{{item}}</option>
+                    </select>
+                  </td>
+                </tr>
+              </table>
+              <p class="error-states" *ngIf="showValidationMessages && !isHoursOfSaleValid()">
+                Hours of Sale are required
+              </p>
+            </div>
+          </section>
+
           <!-- Licensed Producer -->
           <div *ngIf="application?.applicationType?.name === ApplicationTypeNames.Marketer">
             <h3 class="blue-header">INFORMATION ABOUT THE LICENSED PRODUCER</h3>

--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
@@ -35,6 +35,17 @@ import { faExclamationCircle, faTrashAlt, faUniversity } from '@fortawesome/free
 import { faCreditCard, faIdCard, faSave } from '@fortawesome/free-regular-svg-icons';
 import { RelatedLicence } from "@models/related-licence";
 
+const ServiceHours = [
+  '00:00', '00:15', '00:30', '00:45', '01:00', '01:15', '01:30', '01:45', '02:00', '02:15', '02:30', '02:45', '03:00',
+  '03:15', '03:30', '03:45', '04:00', '04:15', '04:30', '04:45', '05:00', '05:15', '05:30', '05:45', '06:00', '06:15',
+  '06:30', '06:45', '07:00', '07:15', '07:30', '07:45', '08:00', '08:15', '08:30', '08:45',
+  '09:00', '09:15', '09:30',
+  '09:45', '10:00', '10:15', '10:30', '10:45', '11:00', '11:15', '11:30', '11:45', '12:00', '12:15', '12:30', '12:45',
+  '13:00', '13:15', '13:30', '13:45', '14:00', '14:15', '14:30', '14:45', '15:00', '15:15', '15:30', '15:45', '16:00',
+  '16:15', '16:30', '16:45', '17:00', '17:15', '17:30', '17:45', '18:00', '18:15', '18:30', '18:45', '19:00', '19:15',
+  '19:30', '19:45', '20:00', '20:15', '20:30', '20:45', '21:00', '21:15', '21:30', '21:45', '22:00', '22:15', '22:30',
+  '22:45', '23:00', '23:15', '23:30', '23:45'
+];
 
 @Component({
   selector: 'app-application',
@@ -68,6 +79,7 @@ export class ApplicationComponent extends FormBase implements OnInit {
   validationMessages: any[];
   showValidationMessages: boolean;
   submittedApplications = 8;
+  ServiceHours = ServiceHours;
   tiedHouseFormData: TiedHouseConnection;
   possibleProblematicNameWarning = false;
   htmlContent: ApplicationHTMLContent = <ApplicationHTMLContent>{};
@@ -174,6 +186,20 @@ export class ApplicationComponent extends FormBase implements OnInit {
       tempSuspensionOrPatronParticipationStart: [''],
       tempSuspensionOrPatronParticipationEnd: [''],
       establishmentPhone: [''],
+      serviceHoursSundayOpen: [''],
+      serviceHoursMondayOpen: [''],
+      serviceHoursTuesdayOpen: [''],
+      serviceHoursWednesdayOpen: [''],
+      serviceHoursThursdayOpen: [''],
+      serviceHoursFridayOpen: [''],
+      serviceHoursSaturdayOpen: [''],
+      serviceHoursSundayClose: [''],
+      serviceHoursMondayClose: [''],
+      serviceHoursTuesdayClose: [''],
+      serviceHoursWednesdayClose: [''],
+      serviceHoursThursdayClose: [''],
+      serviceHoursFridayClose: [''],
+      serviceHoursSaturdayClose: [''],
       liquorDeclarationCheck: [''],
       applyAsIndigenousNation: [false],
       indigenousNationId: [{ value: null, disabled: true }, Validators.required],
@@ -250,6 +276,62 @@ export class ApplicationComponent extends FormBase implements OnInit {
 
     this.form.get('establishmentParcelId').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
       this.form.get('pin').updateValueAndValidity();
+    });
+
+    this.form.get('serviceHoursSundayOpen').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursSundayClose');
+    });
+
+    this.form.get('serviceHoursSundayClose').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursSundayOpen');
+    });
+
+    this.form.get('serviceHoursMondayOpen').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursMondayClose');
+    });
+
+    this.form.get('serviceHoursMondayClose').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursMondayOpen');
+    });
+
+    this.form.get('serviceHoursTuesdayOpen').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursTuesdayClose');
+    });
+
+    this.form.get('serviceHoursTuesdayClose').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursTuesdayOpen');
+    });
+
+    this.form.get('serviceHoursWednesdayOpen').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursWednesdayClose');
+    });
+
+    this.form.get('serviceHoursWednesdayClose').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursWednesdayOpen');
+    });
+
+    this.form.get('serviceHoursThursdayOpen').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursThursdayClose');
+    });
+
+    this.form.get('serviceHoursThursdayClose').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursThursdayOpen');
+    });
+    
+    this.form.get('serviceHoursFridayOpen').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursFridayClose');
+    });
+
+    this.form.get('serviceHoursFridayClose').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursFridayOpen');
+    });
+
+    this.form.get('serviceHoursSaturdayOpen').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursSaturdayClose');
+    });
+
+    this.form.get('serviceHoursSaturdayClose').valueChanges.pipe(distinctUntilChanged()).subscribe(val => {
+      this.updateRequiredValidator(val, 'serviceHoursSaturdayOpen');
     });
   
     this.form.get('indigenousNation').valueChanges
@@ -571,6 +653,25 @@ export class ApplicationComponent extends FormBase implements OnInit {
       this.form.get('establishmentPhone').disable();
     }
 
+    if (!this.application.applicationType.showHoursOfSale || this.application.applicationType.name === ApplicationTypeNames.FP || this.application.applicationType.name === ApplicationTypeNames.FPRelo) {
+      // Opening hours
+      this.form.get('serviceHoursSundayOpen').disable();
+      this.form.get('serviceHoursMondayOpen').disable();
+      this.form.get('serviceHoursTuesdayOpen').disable();
+      this.form.get('serviceHoursWednesdayOpen').disable();
+      this.form.get('serviceHoursThursdayOpen').disable();
+      this.form.get('serviceHoursFridayOpen').disable();
+      this.form.get('serviceHoursSaturdayOpen').disable();
+      // Closing hours
+      this.form.get('serviceHoursSundayClose').disable();
+      this.form.get('serviceHoursMondayClose').disable();
+      this.form.get('serviceHoursTuesdayClose').disable();
+      this.form.get('serviceHoursWednesdayClose').disable();
+      this.form.get('serviceHoursThursdayClose').disable();
+      this.form.get('serviceHoursFridayClose').disable();
+      this.form.get('serviceHoursSaturdayClose').disable();
+    }
+
     if (this.application.applicationType.name !== ApplicationTypeNames.Marketer) {
       this.form.get('federalProducerNames').disable();
     }
@@ -645,6 +746,106 @@ export class ApplicationComponent extends FormBase implements OnInit {
     }
 
     return false;
+  }
+
+  private isHoursOfSaleValid(): boolean {
+    return this.form.disabled || !this.application.applicationType.showHoursOfSale ||
+        this.application.applicationType.name === ApplicationTypeNames.FP ||
+        this.application.applicationType.name === ApplicationTypeNames.FPRelo ||
+      (this.form.get('serviceHoursSundayOpen').valid
+        && this.form.get('serviceHoursMondayOpen').valid
+        && this.form.get('serviceHoursTuesdayOpen').valid
+        && this.form.get('serviceHoursWednesdayOpen').valid
+        && this.form.get('serviceHoursThursdayOpen').valid
+        && this.form.get('serviceHoursFridayOpen').valid
+        && this.form.get('serviceHoursSaturdayOpen').valid
+        && this.form.get('serviceHoursSundayClose').valid
+        && this.form.get('serviceHoursMondayClose').valid
+        && this.form.get('serviceHoursTuesdayClose').valid
+        && this.form.get('serviceHoursWednesdayClose').valid
+        && this.form.get('serviceHoursThursdayClose').valid
+        && this.form.get('serviceHoursFridayClose').valid
+        && this.form.get('serviceHoursSaturdayClose').valid
+      );
+  }
+
+  private isHoursPopulated(hoursOpen, hoursClose, altHoursOpen): boolean {
+    if (hoursOpen != '' && hoursClose != '') {
+      var timeTokensOpen = hoursOpen.split(':');
+      var timeTokensClose = hoursClose.split(':');
+      var timeTokensAltOpen = altHoursOpen.split(':');
+      let openDate = new Date(1970, 0, 2, timeTokensOpen[0], timeTokensOpen[1]);
+      let closeDate = new Date(1970, 0, 2, timeTokensClose[0], timeTokensClose[1]);
+      if (closeDate.getTime() < openDate.getTime()) {
+        //Open time may be the day before.  ie) Open Saturday at 9am Close Sunday 2am
+        openDate = new Date(1970, 0, 1, timeTokensAltOpen[0], timeTokensAltOpen[1]);
+      }
+      let minutes = (closeDate.getTime() - openDate.getTime()) / 60000; // minutes between
+      if (minutes <= 0) {
+        return false;
+      } else {
+        return true;
+      }
+    }
+  }
+
+  private isHoursOfSalePopulated(): boolean {
+    if (!this.application.applicationType.showHoursOfSale ||
+      this.application.applicationType.name === ApplicationTypeNames.FP ||
+      this.application.applicationType.name === ApplicationTypeNames.FPRelo) {
+      return true;
+    }
+    if (this.form.get('serviceHoursSundayOpen').value != '' && this.form.get('serviceHoursSundayClose').value != '' && this.form.get('serviceHoursSaturdayOpen').value != '') {
+      if (!this.isHoursPopulated(this.form.get('serviceHoursSundayOpen').value, this.form.get('serviceHoursSundayClose').value, this.form.get('serviceHoursSaturdayOpen').value)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    if (this.form.get('serviceHoursMondayOpen').value != '' && this.form.get('serviceHoursMondayClose').value != '' && this.form.get('serviceHoursSundayOpen').value != '') {
+      if (!this.isHoursPopulated(this.form.get('serviceHoursMondayOpen').value, this.form.get('serviceHoursMondayClose').value, this.form.get('serviceHoursSundayOpen').value)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    if (this.form.get('serviceHoursTuesdayOpen').value != '' && this.form.get('serviceHoursTuesdayClose').value != '' && this.form.get('serviceHoursMondayOpen').value != '') {
+      if (!this.isHoursPopulated(this.form.get('serviceHoursTuesdayOpen').value, this.form.get('serviceHoursTuesdayClose').value, this.form.get('serviceHoursMondayOpen').value)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    if (this.form.get('serviceHoursWednesdayOpen').value != '' && this.form.get('serviceHoursWednesdayClose').value != '' && this.form.get('serviceHoursTuesdayOpen').value != '') {
+      if (!this.isHoursPopulated(this.form.get('serviceHoursWednesdayOpen').value, this.form.get('serviceHoursWednesdayClose').value, this.form.get('serviceHoursTuesdayOpen').value)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    if (this.form.get('serviceHoursThursdayOpen').value != '' && this.form.get('serviceHoursThursdayClose').value != '' && this.form.get('serviceHoursWednesdayOpen').value != '') {
+      if (!this.isHoursPopulated(this.form.get('serviceHoursThursdayOpen').value, this.form.get('serviceHoursThursdayClose').value, this.form.get('serviceHoursWednesdayOpen').value)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    if (this.form.get('serviceHoursFridayOpen').value != '' && this.form.get('serviceHoursFridayClose').value != '' && this.form.get('serviceHoursThursdayOpen').value != '') {
+      if (!this.isHoursPopulated(this.form.get('serviceHoursFridayOpen').value, this.form.get('serviceHoursFridayClose').value, this.form.get('serviceHoursThursdayOpen').value)) {
+        return false;
+      }
+    } else {
+      return false;
+    }
+    if (this.form.get('serviceHoursSaturdayOpen').value != '' && this.form.get('serviceHoursSaturdayClose').value != '' && this.form.get('serviceHoursFridayOpen').value != '') {
+      if (!this.isHoursPopulated(this.form.get('serviceHoursSaturdayOpen').value, this.form.get('serviceHoursSaturdayClose').value, this.form.get('serviceHoursFridayOpen').value)) {
+        return false;
+      }
+    }
+    else {
+      return false;
+    }
+    return true;
   }
 
   lgHasReviewedZoning(): boolean {
@@ -1216,6 +1417,11 @@ export class ApplicationComponent extends FormBase implements OnInit {
     if (applicationTypeName === ApplicationTypeNames.CannabisRetailStore && this.submittedApplications >= 8) {
       valid = false;
       this.validationMessages.push('Only 8 applications can be submitted');
+    }
+
+    if (!this.isHoursOfSaleValid() || !this.isHoursOfSalePopulated()) {
+      valid = false;
+      this.validationMessages.push('Hours of sale are required');
     }
 
     if (this.application.applicationType.showOwnershipDeclaration) {


### PR DESCRIPTION
This code was removed in the PR #4240 for the temporary relocation portal changes, but currently there is no way for licensees to edit the hours of sale. The entire field is missing in several applications like the 'Change to Hours of Liquor Service'. 