### PR TITLE
LCSD-6596 update error message for policy document

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/policy-document/policy-document.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/policy-document/policy-document.component.html
@@ -10,6 +10,9 @@
     </div>
   </div>
   <section *ngIf="!policyDocument && dataLoaded" class="h1">
-    Network issues are preventing the retrieval of this content. Please try again in a few minutes.
+    <p>Page Not found.</p>
+
+    <p>Find information about <a href="https://www2.gov.bc.ca/gov/content?id=BE1251A4F9AC438E97035EC1F2B0A9ED">liquor law and policy</a> or <a href="https://www2.gov.bc.ca/gov/content?id=885DA343124343C7B4BDE187D96164A1">cannabis law and policy</a>.<br/>
+    Find <a href="https://www2.gov.bc.ca/gov/content?id=A23EC0509C9C469188BBA68C3342769D">bulletins about recent policy changes</a>.</p>
   </section>
 </div>

--- a/cllc-public-app/ClientApp/src/app/components/policy-document/policy-document.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/policy-document/policy-document.component.scss
@@ -17,7 +17,7 @@ h3 {
 }
 
 p {
-    padding-left: 300px;
+    padding-left: 30px;
 }
 
 .contentPolicy {


### PR DESCRIPTION
Misleading/incorrect error message attribute not-found error to network
problem. Change this text to a simple "Page Not Found" text, and add
links to polices and bulletins. (provided by Coms)
