### PR TITLE
LCSD-7540: Increase text size and add margin to 'Print Page' on SEP Summary

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/sep/error-alert/error-alert.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/sep/error-alert/error-alert.component.scss
@@ -2,6 +2,7 @@
 .sep-error {
     padding: 16px;
     margin-top: 8px;
+    margin-bottom: 8px;
     max-width: 800px;
     border-radius: 5px;
     fa-icon {

--- a/cllc-public-app/ClientApp/src/app/components/sep/payment-confirmation/payment-confirmation.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/sep/payment-confirmation/payment-confirmation.component.scss
@@ -25,5 +25,6 @@
     color: #1a5a96;
     float: right;
     margin-top: 10px;
+    font-size: large;
   }
   

--- a/cllc-public-app/ClientApp/src/app/components/sep/sep-application/summary/summary.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/sep/sep-application/summary/summary.component.scss
@@ -55,4 +55,7 @@
       text-align: center;
       width: 240px;
     }
+    .print-page {
+        font-size: large;
+    }
 }

--- a/cllc-public-app/ClientApp/src/app/components/sep/sep-application/summary/summary.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/sep/sep-application/summary/summary.component.ts
@@ -26,6 +26,7 @@ import {
   faExclamationTriangle,
   faFlag,
   faPencilAlt,
+  faPrint,
   faQuestionCircle,
   faShoppingCart,
   faStopwatch,
@@ -68,6 +69,7 @@ export class SummaryComponent implements OnInit {
   faBolt = faBolt;
   faCheck = faCheck;
   faBan = faBan;
+  faPrint = faPrint;
   /**
    * Controls whether or not the form show the submit button.
    * The value true by default


### PR DESCRIPTION
Also fixed an import on the `faPrint` icon that now displays a print icon. 