### PR TITLE
LCSD-6279: Add Form Validation for Ownership Details

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.html
@@ -2342,11 +2342,13 @@
                 <section>
                   <div>
                     <mat-checkbox formControlName="isOwnerBusiness">
+                      <span class="error-states">*</span>
                       The applicant is the owner of the business in respect of which the licence is to be issued or will become the owner before the licence is issued.
                     </mat-checkbox>
                   </div>
                   <div>
                     <mat-checkbox formControlName="hasValidInterest">
+                      <span class="error-states">*</span>
                       At the time of this submission, the applicant is:
                       <ul>
                         <li>
@@ -2363,6 +2365,7 @@
                   </div>
                   <div>
                     <mat-checkbox formControlName="willHaveValidInterest">
+                      <span class="error-states">*</span>
                       At the time the licence is issued, the applicant will be:
                       <ul>
                         <li>The owner of the place or premises that forms the establishment, or</li>

--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
@@ -1459,14 +1459,17 @@ export class ApplicationComponent extends FormBase implements OnInit {
     if (this.application.applicationType.showOwnershipDeclaration) {
 
       if (!this.form.get('isOwner').value && !(this.form.get('isOwnerBusiness') && this.form.get('isOwnerBusiness').value)) {
+        valid = false;
         this.validationMessages.push('Only the owner of the business may submit this information');
       }
 
       if (!this.form.get('hasValidInterest').value) {
+        valid = false;
         this.validationMessages.push('The owner of the business must own or have an agreement to purchase the proposed establishment, or, be the lessee or have a binding agreement to lease the proposed establishment');
       }
 
       if (!this.form.get('willHaveValidInterest').value) {
+        valid = false;
         this.validationMessages.push('Ownership or the lease agreement must be in place at the time of licensing');
       }
 


### PR DESCRIPTION
https://jira.justice.gov.bc.ca/browse/LCSD-6276

Previously, the ownership details would generate an error message but did not set the form to invalid. This would allow form submissions without checking these declarations. I have added this validation and also a red asterisk to indicate that these are mandatory fields.

![image](https://github.com/user-attachments/assets/126502de-f2d0-4929-8bb0-deae93d946f7)
