### PR TITLE
LCSD-7057: Added Valid Interest to RLRS Licence Type

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
@@ -2015,7 +2015,9 @@ export class ApplicationComponent extends FormBase implements OnInit {
 
   showValidInterestforTransfer() {
     return (this.application.applicationType.name === ApplicationTypeNames.LiquorLicenceTransfer &&
-      (this.application.licenseType === "Licensee Retail Store" || this.application.licenseType === "Wine Store"));
+      (this.application.licenseType === "Licensee Retail Store" 
+        || this.application.licenseType === "Wine Store"
+        || this.application.licenseType === "Rural Licensee Retail Store"));
   }
 
   showDynamicForm(formReference, tabs) {


### PR DESCRIPTION
The `showValidInterestforTransfer()` did not include RLRS licence types which was preventing the drop box to show on the application. 

Jira Ticket: https://jira.justice.gov.bc.ca/browse/LCSD-7057
