### PR TITLE
LCSD-7786: Create Policy for BC Service Card Users

### DIFF
--- a/cllc-public-app/Controllers/FeedbackController.cs
+++ b/cllc-public-app/Controllers/FeedbackController.cs
@@ -25,8 +25,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
 
     [Route("api/[controller]")]
     [ApiController]
-    [Authorize(Policy = "Business-User")]
-    [Authorize(Policy = "Service-Card-User")]
+    [Authorize(Policy = "Existing-User")]
     public class FeedbackController : ControllerBase
     {
 

--- a/cllc-public-app/Controllers/FeedbackController.cs
+++ b/cllc-public-app/Controllers/FeedbackController.cs
@@ -26,6 +26,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
     [Route("api/[controller]")]
     [ApiController]
     [Authorize(Policy = "Business-User")]
+    [Authorize(Policy = "Service-Card-User")]
     public class FeedbackController : ControllerBase
     {
 

--- a/cllc-public-app/Startup.cs
+++ b/cllc-public-app/Startup.cs
@@ -148,6 +148,15 @@ namespace Gov.Lclb.Cllb.Public
                                       || context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.NewUserRegistration));
                                       return res;
                                   }));
+                // This policy is used for existing bc services card accounts
+                options.AddPolicy("Service-Card-User", policy =>
+                                  policy.RequireAssertion(context =>
+                                  {
+                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && c.Value == "VerfiedIndividual")
+                                      && context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.ExistingUser);
+                                      return res;
+                                  }));
+
             });
             services.RegisterPermissionHandler();
             if (!string.IsNullOrEmpty(_configuration["KEY_RING_DIRECTORY"]))

--- a/cllc-public-app/Startup.cs
+++ b/cllc-public-app/Startup.cs
@@ -149,10 +149,10 @@ namespace Gov.Lclb.Cllb.Public
                                       return res;
                                   }));
                 // This policy is used for existing bc services card accounts
-                options.AddPolicy("Service-Card-User", policy =>
+                options.AddPolicy("Existing-User", policy =>
                                   policy.RequireAssertion(context =>
                                   {
-                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && c.Value == "VerifiedIndividual")
+                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && (c.Value == "VerifiedIndividual" || c.Value == "Business"))
                                       && context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.ExistingUser);
                                       return res;
                                   }));

--- a/cllc-public-app/Startup.cs
+++ b/cllc-public-app/Startup.cs
@@ -152,7 +152,7 @@ namespace Gov.Lclb.Cllb.Public
                 options.AddPolicy("Service-Card-User", policy =>
                                   policy.RequireAssertion(context =>
                                   {
-                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && c.Value == "VerfiedIndividual")
+                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && c.Value == "VerifiedIndividual")
                                       && context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.ExistingUser);
                                       return res;
                                   }));


### PR DESCRIPTION
In our `Startup.cs`, there is a `Business-User` policy that checks if the current user has a `UserTypeClaim` with value of `Business`, but the users who log in using BC Services Card have the `userType` equal to `VerifiedIndividual`. This would explain why the call to the feedback controller was failing. 

Another interesting observation is that the SEP controller has the policy commented out, likely because it was failing due to this reason. If this fix is working in DEV, I will apply the new policy to the SEP controller as well. 

Jira Ticket: https://jira.justice.gov.bc.ca/browse/LCSD-7786