### PR TITLE
LCSD-7786: Revert New Policy and Remove it From Feedback Controller

### DIFF
--- a/cllc-public-app/Controllers/FeedbackController.cs
+++ b/cllc-public-app/Controllers/FeedbackController.cs
@@ -25,8 +25,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
 
     [Route("api/[controller]")]
     [ApiController]
-    [Authorize(Policy = "Business-User")]
-    [Authorize(Policy = "Service-Card-User")]
+    [Authorize(Policy = "Existing-User")]
     public class FeedbackController : ControllerBase
     {
 

--- a/cllc-public-app/Controllers/FeedbackController.cs
+++ b/cllc-public-app/Controllers/FeedbackController.cs
@@ -26,6 +26,7 @@ namespace Gov.Lclb.Cllb.Public.Controllers
     [Route("api/[controller]")]
     [ApiController]
     [Authorize(Policy = "Business-User")]
+    [Authorize(Policy = "Service-Card-User")]
     public class FeedbackController : ControllerBase
     {
 

--- a/cllc-public-app/Controllers/FeedbackController.cs
+++ b/cllc-public-app/Controllers/FeedbackController.cs
@@ -25,7 +25,6 @@ namespace Gov.Lclb.Cllb.Public.Controllers
 
     [Route("api/[controller]")]
     [ApiController]
-    [Authorize(Policy = "Existing-User")]
     public class FeedbackController : ControllerBase
     {
 

--- a/cllc-public-app/Startup.cs
+++ b/cllc-public-app/Startup.cs
@@ -148,6 +148,15 @@ namespace Gov.Lclb.Cllb.Public
                                       || context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.NewUserRegistration));
                                       return res;
                                   }));
+                // This policy is used for existing bc services card accounts
+                options.AddPolicy("Service-Card-User", policy =>
+                                  policy.RequireAssertion(context =>
+                                  {
+                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && c.Value == "VerfiedIndividual")
+                                      && context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.ExistingUser);
+                                      return res;
+                                  }));
+
             });
             services.RegisterPermissionHandler();
             if (!string.IsNullOrEmpty(_configuration["KEY_RING_DIRECTORY"]))

--- a/cllc-public-app/Startup.cs
+++ b/cllc-public-app/Startup.cs
@@ -148,15 +148,6 @@ namespace Gov.Lclb.Cllb.Public
                                       || context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.NewUserRegistration));
                                       return res;
                                   }));
-                // This policy is used for existing bc services card accounts
-                options.AddPolicy("Existing-User", policy =>
-                                  policy.RequireAssertion(context =>
-                                  {
-                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && (c.Value == "VerifiedIndividual" || c.Value == "Business"))
-                                      && context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.ExistingUser);
-                                      return res;
-                                  }));
-
             });
             services.RegisterPermissionHandler();
             if (!string.IsNullOrEmpty(_configuration["KEY_RING_DIRECTORY"]))

--- a/cllc-public-app/Startup.cs
+++ b/cllc-public-app/Startup.cs
@@ -149,10 +149,10 @@ namespace Gov.Lclb.Cllb.Public
                                       return res;
                                   }));
                 // This policy is used for existing bc services card accounts
-                options.AddPolicy("Service-Card-User", policy =>
+                options.AddPolicy("Existing-User", policy =>
                                   policy.RequireAssertion(context =>
                                   {
-                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && c.Value == "VerifiedIndividual")
+                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && (c.Value == "VerifiedIndividual" || c.Value == "Business"))
                                       && context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.ExistingUser);
                                       return res;
                                   }));

--- a/cllc-public-app/Startup.cs
+++ b/cllc-public-app/Startup.cs
@@ -152,7 +152,7 @@ namespace Gov.Lclb.Cllb.Public
                 options.AddPolicy("Service-Card-User", policy =>
                                   policy.RequireAssertion(context =>
                                   {
-                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && c.Value == "VerfiedIndividual")
+                                      var res = context.User.HasClaim(c => c.Type == User.UserTypeClaim && c.Value == "VerifiedIndividual")
                                       && context.User.HasClaim(c => c.Type == User.PermissionClaim && c.Value == Permission.ExistingUser);
                                       return res;
                                   }));


### PR DESCRIPTION
The new policy did not work as expected as the feedback submission from the SEP portal still resulted in a 403 error. However, we do not need to add the `[Authorize]` attribute as SiteMinder is configured to authenticate requests. It seems that this attribute is used to restrict certain content for different user types and is not needed in this controller. 