### PR TITLE
BugFix: Duplicate Account URLs

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
@@ -410,6 +410,9 @@ export class AccountProfileComponent extends FormBase implements OnInit {
     // Transform the accountUrls comma-separated string into an array
     const accountUrlsArray = this.splitAccountURLString(accountUrls);
     const accountUrlsArrayControl = this.form.get("businessProfile.accountUrls") as FormArray;
+    // Clear the existing account form controls, if any, so duplicate controls are not created if this function is
+    // called multiple times
+    accountUrlsArrayControl.clear();
     for (const accountUrl of accountUrlsArray) {
         // Add a form control for each account URL
         accountUrlsArrayControl.push(this.fb.control(accountUrl, [this.urlValidator]));


### PR DESCRIPTION
## Original Ticket

https://jira.justice.gov.bc.ca/browse/LCSD-7814

## Description

Noticed a bug where if you edited and saved the profile form, and re-loaded the page quickly, you would occasionally see the account url controls duplicated. It seems the subscription to fetch the form data occasionally emits twice, and the account urls were being added twice as a result. Only impacts array fields, since non-array fields just replace their value, rather than push into the array.
