### PR TITLE
LCSD-6537 One stop AccountDetailsBroadcast bug fix

### DIFF
--- a/one-stop-service/Controllers/OneStopController.cs
+++ b/one-stop-service/Controllers/OneStopController.cs
@@ -14,12 +14,14 @@ namespace one_stop_service.Controllers
         private readonly IConfiguration Configuration;
         private readonly IMemoryCache _cache;
         private readonly ILogger _logger;
+        private readonly IReceiveFromHubService _hubService;
 
-        public OneStopController(IConfiguration configuration, IMemoryCache cache)
+        public OneStopController(IConfiguration configuration, IMemoryCache cache, IReceiveFromHubService hubService)
         {
             Configuration = configuration;
             _cache = cache;
             _logger = Log.Logger;
+            _hubService = hubService;
 
 
         }
@@ -88,13 +90,13 @@ namespace one_stop_service.Controllers
             return Ok();
         }
 
-        [HttpGet("SendProgramAccountDetailsBroadcastMessage/{licenceGuid}")]
-        public IActionResult SendProgramAccountDetailsBroadcastMessage(string licenceGuid)
+        [HttpGet("SendProgramAccountDetailsBroadcastMessage/{licenceGuid}/{itemId}")]
+        public IActionResult SendProgramAccountDetailsBroadcastMessage(string licenceGuid, string itemId)
         {
             _logger.Information("Reached SendProgramAccountDetailsBroadcastMessage");
-            BackgroundJob.Enqueue(() => new OneStopUtils(Configuration, _cache).SendProgramAccountDetailsBroadcastMessageRest(null, licenceGuid));
+            BackgroundJob.Enqueue(() => new OneStopUtils(Configuration, _cache).SendProgramAccountDetailsBroadcastMessageRest(null, licenceGuid, itemId));
             return Ok();
-        }
+        }        
 
 
     }

--- a/one-stop-service/ReceiveFromHubService.cs
+++ b/one-stop-service/ReceiveFromHubService.cs
@@ -179,8 +179,7 @@ namespace Gov.Jag.Lcrb.OneStopService
 
 
 
-                //Trigger the Send ProgramAccountDetailsBroadcast Message                
-                BackgroundJob.Enqueue(() => new OneStopUtils(_configuration, _cache).SendProgramAccountDetailsBroadcastMessageRest(null, licence.AdoxioLicencesid));
+                CreateOneStopBroadcastItem(dynamicsClient, licence.AdoxioLicencesid, inputXML);
 
                 Log.Logger.Information("send program account details broadcast done.");
             }
@@ -313,5 +312,26 @@ namespace Gov.Jag.Lcrb.OneStopService
             return result;
 
         }
+
+        private void CreateOneStopBroadcastItem(IDynamicsClient dynamicsClient, string licenceId, string payload)
+        {
+            MicrosoftDynamicsCRMadoxioOnestopmessageitem item =
+                new MicrosoftDynamicsCRMadoxioOnestopmessageitem()
+                {
+                    AdoxioPayload = payload,
+                    AdoxioLicenceODataBind = "/adoxio_licenceses(" + licenceId + ")",
+                    AdoxioStatuschangedescription = (int)OneStopHubStatusChange.Issued
+                };
+            try
+            {
+                dynamicsClient.Onestopmessageitems.Create(item);
+            }
+            catch (HttpOperationException odee)
+            {
+                Log.Logger.Error(odee, $"ERROR updating queue items for OneStop license {licenceId}");
+
+            }
+        }
+
     }
 }


### PR DESCRIPTION
Changes made:
- Account Details Broadcast added to one stop status description drop down which can be used to manually trigger  AccountDetailsBroadcast.
- When portal receives a  CreateProgramAccountResponse it creates a one stop message item that will be picked up and added to the que by hangfire to send AccountDetailsBroadcast.
- AccountDetailsBroadcast Api addedto manually trigger response.