### PR TITLE
LCSD-7182: disable generate ovr button when account has url

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.html
@@ -380,8 +380,8 @@
       </p>
 
     </div>
-  </section>
-  <!-- 2024-09-13: Temporary disabling this until further development work can be completed to support this feature. -->
+   </section>
+  <!-- 2024-09-13: Temporary disabling this until further development work can be completed to support this feature.-->
   <!-- <section class="submit-container" style="background-color: #F2F2F2; border: none; color: #000;">
     <h2 style="color: #000">Online Retailer Verification:</h2>
     <div class="submit-content">
@@ -392,7 +392,7 @@
       </p>
     </div>
     <div style="display: flex; justify-content: center;">
-      <button class="btn btn-primary" color="primary" (click)="openBadgeTemplateDialog()">
+      <button class="btn btn-primary" color="primary" (click)="openBadgeTemplateDialog()" [disabled]="accountUrls?.controls?.length > 1 || accountUrls?.controls[0].value" [attr.title]="(accountUrls?.controls?.length > 1 || accountUrls?.controls[0].value)? 'Can not generate ORV Code if account has URL(s)': null">
           <span class="compact-button">Generate ORV Code</span>
       </button>
     </div>

--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
@@ -1330,6 +1330,8 @@ export class ApplicationComponent extends FormBase implements OnInit {
       }, (err: any) => {
         if (err._body === 'Payment already made') {
           this.snackBar.open('Application payment has already been made, please refresh the page.', 'Fail', { duration: 3500, panelClass: ['red-snackbar'] });
+          this.paymentDataService.verifyPaymentSubmission(this.applicationId).subscribe(
+            res => {})
         }
       }));
   }

--- a/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/applications/application/application.component.ts
@@ -1330,8 +1330,6 @@ export class ApplicationComponent extends FormBase implements OnInit {
       }, (err: any) => {
         if (err._body === 'Payment already made') {
           this.snackBar.open('Application payment has already been made, please refresh the page.', 'Fail', { duration: 3500, panelClass: ['red-snackbar'] });
-          this.paymentDataService.verifyPaymentSubmission(this.applicationId).subscribe(
-            res => {})
         }
       }));
   }


### PR DESCRIPTION
Changes made when account has multiple urls or one that is not blank Generate Url is disabled.
![image](https://github.com/user-attachments/assets/c05f8ec3-efdd-4169-a1c4-3a53a0a80b53)
