### PR TITLE
Onestop send account broadcast error

### DIFF
--- a/cllc-interfaces/Dynamics-Autorest/ModelExtensions/OneStopHubStatusChangeType.cs
+++ b/cllc-interfaces/Dynamics-Autorest/ModelExtensions/OneStopHubStatusChangeType.cs
@@ -25,5 +25,6 @@ namespace Gov.Lclb.Cllb.Interfaces.Models
         [Display(Name = "Expired")] Expired = 845280011,
         [Display(Name = "Renewed")] Renewed = 845280012,
         [Display(Name = "Updated - Endorsement Approved")] EndorsementApproved = 845280016,
+        [Display(Name = "Account Details Broadcast")] AccountDetailsBroadcast = 845280018,
     }
 }

--- a/one-stop-service/OneStopUtils.cs
+++ b/one-stop-service/OneStopUtils.cs
@@ -406,7 +406,7 @@ namespace Gov.Jag.Lcrb.OneStopService
         /// <summary>
         /// Hangfire job to send LicenceDetailsMessage to One stop.
         /// </summary>
-        public async Task SendProgramAccountDetailsBroadcastMessageRest(PerformContext hangfireContext, string licenceGuidRaw)
+        public async Task SendProgramAccountDetailsBroadcastMessageRest(PerformContext hangfireContext, string licenceGuidRaw, string queueItemId)
         {
             IDynamicsClient dynamicsClient = DynamicsSetupUtil.SetupDynamics(_configuration);
             if (hangfireContext != null)
@@ -456,6 +456,7 @@ namespace Gov.Jag.Lcrb.OneStopService
                 //send message to Onestop hub
                 var outputXML = await _onestopRestClient.ReceiveFromPartner(innerXml);
 
+                UpdateQueueItemForSend(dynamicsClient, hangfireContext, queueItemId, innerXml, outputXML);
                 if (hangfireContext != null)
                 {
                     hangfireContext.WriteLine(outputXML);
@@ -606,6 +607,9 @@ namespace Gov.Jag.Lcrb.OneStopService
                             case OneStopHubStatusChange.LicenceDeemedAtTransfer:
                                 await SendChangeNameRest(hangfireContext, licenceId,
                                     queueItem.AdoxioOnestopmessageitemid, true, ChangeNameType.Transfer);
+                                break;
+                            case OneStopHubStatusChange.AccountDetailsBroadcast:
+                                await SendProgramAccountDetailsBroadcastMessageRest(hangfireContext, licenceId, queueItem.AdoxioOnestopmessageitemid);
                                 break;
                             default:
                                 msg = $"Failed updating OneStop queue item {queueItem.AdoxioOnestopmessageitemid}, OneStopHubStatusChange is {queueItem.AdoxioStatuschangedescription} ";


### PR DESCRIPTION
Added missing code from which was causing an issue because AccountDetailsBroadcast was not included in  OneStopHubStatusChangeType.cs enum