### PR TITLE
LCSD-6680: FIx Temporary Use Area (TUA) Event form validation.

### DIFF
--- a/cllc-public-app/ClientApp/.prettierignore
+++ b/cllc-public-app/ClientApp/.prettierignore
@@ -15,4 +15,5 @@ uploads
 .vscode
 
 *.html
-
+*.css
+*.scss

--- a/cllc-public-app/ClientApp/src/app/components/tables/event-location-table/event-location-table.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/tables/event-location-table/event-location-table.component.html
@@ -1,48 +1,51 @@
-<table class="tua-locations">
+<table *ngIf="serviceAreas.length !== 0" class="tua-locations">
   <thead *ngIf="rows.controls.length > 0">
-    <th style="width: 100px">Location ID</th>
-    <th>Location Name</th>
-    <th style="width: 200px">Attendance</th>
-    <th style="width: 45px"></th>
+    <th style="min-width: 100px">Location ID</th>
+    <th style="min-width: 100px">Location Name</th>
+    <th style="width: 100px">Attendance</th>
+    <th style="width: 50px"></th>
   </thead>
-  <tr *ngFor="let row of rows.controls; let i=index" [ngClass]="{ 'text-grey': readonly(i) }">
+  <tr *ngFor="let row of rows.controls; let i = index" [ngClass]="{ 'text-grey': readonly(i) }">
     <ng-container [formGroup]="row">
-      <td>
+      <td style="min-width: 100px">
         <select class="form-control" formControlName="serviceAreaId">
-          <option *ngFor="let item of serviceAreas" [ngValue]="item.id">{{item.areaLocation}}</option>
+          <option *ngFor="let item of serviceAreas" [ngValue]="item.id">{{ item.areaLocation }}</option>
         </select>
       </td>
-      <td>
-        <input type="text" formControlName="name" placeholder="Enter a name for this location"
+      <td style="min-width: 100px">
+        <input type="text" formControlName="name" placeholder="Enter a name for this location" [readonly]="readonly(i)"
+          style="width: 100%" />
+      </td>
+      <td style="width: 100px">
+        <input type="text" formControlName="attendance" placeholder="Enter attendance" mask="0*" maxlength="6"
           [readonly]="readonly(i)" />
       </td>
-      <td>
-        <input type="text" formControlName="attendance" placeholder="Enter attendance" mask="0*" maxlength="4"
-          [readonly]="readonly(i)" />
-      </td>
-      <td>
+      <td style="width: 50px">
         <button type="button" (click)="removeRow(i)" class="btn-clear" *ngIf="!readonly(i)">
           <fa-icon [icon]="faTrash" style="color: #ee220e"></fa-icon>
         </button>
       </td>
     </ng-container>
   </tr>
-  <tr>
-    <td [colSpan]="2" class="pt-3 text-left">
-      <button type="button" (click)="addRow()" class="btn btn-secondary" style="height: 100%;" *ngIf="enabled">
-        <fa-icon [icon]="faPlusCircle" style="color: #1a5a96;"></fa-icon> Add Location
-      </button>
-    </td>
-    <td></td>
-    <td class="text-right">Event Total Attendance:</td>
-    <td>{{total}}</td>
-  </tr>
 </table>
+
+<div *ngIf="serviceAreas.length === 0" style="margin-bottom: 10px">
+  <span>No service areas defined under the TUA Endorsement. Please add at least one service area first.</span>
+</div>
+
+<div class="tua-locations-actions">
+  <button type="button" (click)="addRow()" class="btn btn-secondary" *ngIf="enabled"
+    [disabled]="serviceAreas.length === 0">
+    <fa-icon [icon]="faPlusCircle" style="color: #1a5a96"></fa-icon>
+    Add Location
+  </button>
+  <span>Event Total Attendance: {{ total }}</span>
+</div>
 <section class="error mt-3" *ngIf="showErrorSection">
   <p *ngFor="let message of validationMessages">
     <span class="app-cancel">
-      <mat-icon aria-label="error icon" style="font-size: 15px;">error</mat-icon>
-      {{message}}
+      <mat-icon aria-label="error icon" style="font-size: 15px">error</mat-icon>
+      {{ message }}
     </span>
   </p>
 </section>

--- a/cllc-public-app/ClientApp/src/app/components/tables/event-location-table/event-location-table.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/tables/event-location-table/event-location-table.component.scss
@@ -8,62 +8,47 @@
   }
 }
 
-table {
+.tua-locations {
   width: 100%;
+  margin-bottom: 1rem;
 
   thead {
     th {
       border: 1px solid black;
       padding: 3px;
       text-align: center;
+
       &:last-child {
         border: none;
       }
     }
   }
+
   tr {
     td {
       background-color: white;
       text-align: center;
       border: 1px solid black;
       height: 35px;
-      &:last-of-type {
-        background: none !important;
-        border: none;
-      }
+
       input {
-        width: 100%;
         height: 100%;
         text-align: center;
         border: none;
       }
     }
-    &:last-child {
-      td {
-        background: none !important;
-        border: none !important;
-      }
-    }
   }
 
-  .btn-save {
-    float: right;
-    background-color: #38598a;
-    border: #38598a 1px solid;
-    border-radius: 3px;
-    color: white;
-    &:hover {
-      background-color: #003366 !important;
-    }
-  }
   .btn-clear {
     background: none;
     border: none;
   }
 }
 
-.bold {
-  font-weight: bold;
+.tua-locations-actions {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
 }
 
 .text-grey {

--- a/cllc-public-app/ClientApp/src/app/components/tua-event/tua-event.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/tua-event/tua-event.component.html
@@ -20,7 +20,7 @@
     <section class="content-bottom clearfix">
       <div class="row">
         <app-field class="col-md-4 col-xs-12" label="Event Name" [required]="true"
-                   [valid]="isValidOrNotTouched('eventName')" errorMessage="Please enter the event name" [isFullWidth]="true">
+          [valid]="isValidOrNotTouched('eventName')" errorMessage="Please enter the event name" [isFullWidth]="true">
           <input class="form-control" type="text" formControlName="eventName">
         </app-field>
       </div>
@@ -30,13 +30,13 @@
     <section class="content-bottom clearfix">
       <div class="row">
         <app-field class="col-md-4 col-xs-12" label="Name" [required]="true" [isFullWidth]="true"
-                   [valid]="isValidOrNotTouched('contactName')" errorMessage="Please enter the contact name">
+          [valid]="isValidOrNotTouched('contactName')" errorMessage="Please enter the contact name">
           <input class="form-control" type="text" formControlName="contactName">
         </app-field>
         <fa-icon [icon]="faQuestionCircle" class="question-mark"
-                 matTooltip="The name of the contact person for the event."></fa-icon>
+          matTooltip="The name of the contact person for the event."></fa-icon>
         <app-field class="col-md-4 col-xs-12" label="Phone" [required]="true" [isFullWidth]="true"
-                   [valid]="isValidOrNotTouched('contactPhone')" errorMessage="Please enter the contact phone number">
+          [valid]="isValidOrNotTouched('contactPhone')" errorMessage="Please enter the contact phone number">
           <input class="form-control" type="text" formControlName="contactPhone" mask="(000) 000-0000">
         </app-field>
       </div>
@@ -46,7 +46,7 @@
     <section class="content-bottom clearfix">
       <p>Specify one or more locations where your event will take place.</p>
       <app-event-location-table formControlName="eventLocations" [enabled]="!isReadOnly"
-                                [serviceAreas]="licence?.serviceAreas" [eventId]="licenceEvent?.id" [shouldValidate]="showErrorSection">
+        [serviceAreas]="licenceEndorsementServiceAreas" [eventId]="licenceEvent?.id" [shouldValidate]="showErrorSection">
       </app-event-location-table>
     </section>
 
@@ -56,18 +56,18 @@
       <p>Note that if you submit a multi-day event, the locations and event details must be the same, otherwise you need
         to submit separate events.</p>
       <div class="row">
-        <app-field class="col-md-2 col-xs-6" label="Start Date" [required]="true"
-                   [valid]="isValidOrNotTouched('startDate')" [isFullWidth]="true">
+        <app-field class="col-md-4 col-xs-6" label="Start Date" [required]="true"
+          [valid]="isValidOrNotTouched('startDate')" [isFullWidth]="true">
           <input type="text" formControlName='startDate' placeholder="yyyy-mm-dd" class="form-control"
-                 [min]="startDateMinimum" [matDatepicker]="startPicker" (focus)="startPicker.open()"
-                 (click)="startPicker.open()" (dateChange)="startDateChanged()">
+            [min]="startDateMinimum" [matDatepicker]="startPicker" (focus)="startPicker.open()"
+            (click)="startPicker.open()" (dateChange)="startDateChanged()">
           <mat-datepicker #startPicker></mat-datepicker>
         </app-field>
-        <app-field class="col-md-2 col-xs-6" label="End Date" [required]="true" [valid]="isValidOrNotTouched('endDate')"
-                   [isFullWidth]="true">
+        <app-field class="col-md-4 col-xs-6" label="End Date" [required]="true" [valid]="isValidOrNotTouched('endDate')"
+          [isFullWidth]="true">
           <input type="text" formControlName='endDate' placeholder="yyyy-mm-dd" class="form-control"
-                 [min]="endDateMinimum" [matDatepicker]="endPicker" (focus)="endPicker.open()" (click)="endPicker.open()"
-                 (dateChange)="endDateChanged()">
+            [min]="endDateMinimum" [matDatepicker]="endPicker" (focus)="endPicker.open()" (click)="endPicker.open()"
+            (dateChange)="endDateChanged()">
           <mat-datepicker #endPicker></mat-datepicker>
         </app-field>
       </div>
@@ -93,7 +93,7 @@
       <div class="row">
         <app-field class="col-xs-12">
           <mat-checkbox [checked]="scheduleIsInconsistent" (change)="toggleScheduleConsistency()"
-                        [disabled]="form.get('startDate').invalid || form.get('endDate').invalid || isReadOnly">
+            [disabled]="form.get('startDate').invalid || form.get('endDate').invalid || isReadOnly">
             The event times are different on specific dates.</mat-checkbox>
         </app-field>
       </div>
@@ -103,8 +103,8 @@
     <section class="content-bottom clearfix">
       <div class="row">
         <app-field class="col-md-4 col-xs-12" label="Event Total Attendance" [required]="true"
-                   [valid]="isValidOrNotTouched('maxAttendance')"
-                   errorMessage="Please enter the maximum attendance (must be a number)" [isFullWidth]="true">
+          [valid]="isValidOrNotTouched('maxAttendance')"
+          errorMessage="Please enter the maximum attendance (must be a number)" [isFullWidth]="true">
           <input class="form-control" type="number" formControlName="maxAttendance">
         </app-field>
         <!--<app-field class="col-md-4 col-xs-12" label="Minors Attending" [enabled]="false" [disabled]="true" [required]="true"
@@ -116,21 +116,21 @@
           </select>
         </app-field>-->
         <app-field class="col-md-4 col-xs-12" label="Event Type" [required]="true"
-                   [valid]="isValidOrNotTouched('tuaEventType')" errorMessage="Please indicate the type of event"
-                   [isFullWidth]="true">
+          [valid]="isValidOrNotTouched('tuaEventType')" errorMessage="Please indicate the type of event"
+          [isFullWidth]="true">
           <select class="form-control" formControlName="tuaEventType">
             <option *ngFor="let item of tuaEventType" [ngValue]="item.value">{{item.label}}</option>
           </select>
         </app-field>
         <fa-icon [icon]="faQuestionCircle" style="color: #38598a; margin-left: 5px; margin-top:30px;"
-                 matTooltip="Select the type of event."></fa-icon>
+          matTooltip="Select the type of event."></fa-icon>
       </div>
 
       <div class="row">
         <app-field class="col-md-8 col-xs-12"
-                   label="Will your permanent licensed establishment also be closed to the public during the event hours?"
-                   [required]="true" [valid]="isValidOrNotTouched('tuaEventType')"
-                   errorMessage="Please indicate if licensed establishment will be closed" [isFullWidth]="false">
+          label="Will your permanent licensed establishment also be closed to the public during the event hours?"
+          [required]="true" [valid]="isValidOrNotTouched('tuaEventType')"
+          errorMessage="Please indicate if licensed establishment will be closed" [isFullWidth]="false">
           <select class="form-control" formControlName="isClosedToPublic">
             <option value="true">Yes</option>
             <option value="false">No</option>
@@ -139,8 +139,8 @@
       </div>
       <div class="row">
         <app-field class="col-md-8 col-xs-12" label="Description" [required]="true"
-                   [valid]="isValidOrNotTouched('eventTypeDescription')" errorMessage="Please enter a description of the event"
-                   [isFullWidth]="true">
+          [valid]="isValidOrNotTouched('eventTypeDescription')" errorMessage="Please enter a description of the event"
+          [isFullWidth]="true">
           <textarea class="form-control" formControlName="eventTypeDescription"></textarea>
         </app-field>
         <fa-icon [icon]="faQuestionCircle" class="question-mark" matTooltip="Briefly describe the event."></fa-icon>
@@ -173,13 +173,13 @@
       <p>We will send the event notification to the contact entered here.</p>
       <div class="row">
         <app-field class="col-md-4 col-xs-12" label="Please provide your email address" [required]="true"
-                   [isFullWidth]="true" [valid]="isValidOrNotTouched('contactEmail')">
+          [isFullWidth]="true" [valid]="isValidOrNotTouched('contactEmail')">
           <input class="form-control" type="text" formControlName="contactEmail">
         </app-field>
       </div>
       <div class="row">
         <app-field class="col-md-4 col-xs-12" label="Retype your email address" [required]="true" [isFullWidth]="true"
-                   [valid]="isValidOrNotTouched('contactEmailConfirmation')">
+          [valid]="isValidOrNotTouched('contactEmailConfirmation')">
           <input class="form-control" type="text" formControlName="contactEmailConfirmation">
         </app-field>
       </div>
@@ -205,7 +205,14 @@
     </section>
 
     <section class="p-3 attention-section">
-      <p>The information requested on this form is collected by the Liquor and Cannabis Regulation Branch under Sections 26 (a), (b) and (c) of the Freedom of Information and Protection of Privacy Act (FOIPPA) for the purpose of liquor and cannabis licensing and compliance and enforcement matters in accordance with the Liquor Control and Licensing Act and Cannabis Control and Licensing Act. Additionally, LCRB may collect personal information under section 26(e) of FOIPPA for the purpose of evaluating LCRB programs and activities to better serve you. Should you have any questions about the collection, use, or disclosure of personal information, please contact the Freedom of Information Officer at PO Box 9292 STN PROV GVT, Victoria, BC, V8W 9J8 or by phone toll free at 1-866-209-2111.</p>
+      <p>The information requested on this form is collected by the Liquor and Cannabis Regulation Branch under Sections
+        26 (a), (b) and (c) of the Freedom of Information and Protection of Privacy Act (FOIPPA) for the purpose of
+        liquor and cannabis licensing and compliance and enforcement matters in accordance with the Liquor Control and
+        Licensing Act and Cannabis Control and Licensing Act. Additionally, LCRB may collect personal information under
+        section 26(e) of FOIPPA for the purpose of evaluating LCRB programs and activities to better serve you. Should
+        you have any questions about the collection, use, or disclosure of personal information, please contact the
+        Freedom of Information Officer at PO Box 9292 STN PROV GVT, Victoria, BC, V8W 9J8 or by phone toll free at
+        1-866-209-2111.</p>
     </section>
 
     <section class="error mt-3" *ngIf="showErrorSection">

--- a/cllc-public-app/ClientApp/src/app/components/tua-event/tua-event.component.scss
+++ b/cllc-public-app/ClientApp/src/app/components/tua-event/tua-event.component.scss
@@ -48,4 +48,5 @@
 .event-hours {
   background-color: #e1e8f2;
   border-bottom: 4px solid #e4e4e4;
+  margin-bottom: 10px;
 }

--- a/cllc-public-app/ClientApp/src/app/models/endorsement.model.ts
+++ b/cllc-public-app/ClientApp/src/app/models/endorsement.model.ts
@@ -4,6 +4,9 @@ export class Endorsement {
   applicationTypeId: string;
   applicationTypeName: string;
   hoursOfServiceList: HoursOfService[];
+  /**
+   * The sum total capacity of all service areas under this endorsement.
+   */
   areaCapacity: number;
 }
 export class HoursOfService {

--- a/cllc-public-app/ClientApp/src/app/models/service-area.model.ts
+++ b/cllc-public-app/ClientApp/src/app/models/service-area.model.ts
@@ -1,4 +1,3 @@
-
 export enum AreaCategory {
   Service = 845280000,
   OutsideArea = 845280001,
@@ -15,4 +14,5 @@ export class ServiceArea {
   isPatio: boolean;
   capacity: string;
   isTemporaryExtensionArea: boolean;
+  endorsementId?: string;
 }

--- a/cllc-public-app/Models.Extensions/CapacityArea.cs
+++ b/cllc-public-app/Models.Extensions/CapacityArea.cs
@@ -1,4 +1,5 @@
-﻿using Gov.Lclb.Cllb.Interfaces.Models;
+﻿using System;
+using Gov.Lclb.Cllb.Interfaces.Models;
 using Gov.Lclb.Cllb.Public.ViewModels;
 
 namespace Gov.Lclb.Cllb.Public.Models
@@ -10,7 +11,7 @@ namespace Gov.Lclb.Cllb.Public.Models
             return new CapacityArea
             {
                 Id = serviceArea.AdoxioServiceareaid,
-                // we can not cast to int when  the value is null. 
+                // we can not cast to int when  the value is null.
                 AreaNumber = serviceArea.AdoxioAreanumber == null ? 0 : (int)serviceArea.AdoxioAreanumber,
                 AreaCategory = serviceArea.AdoxioAreacategory,
                 AreaLocation = serviceArea.AdoxioArealocation,
@@ -18,7 +19,10 @@ namespace Gov.Lclb.Cllb.Public.Models
                 IsOutdoor = serviceArea.AdoxioIsoutdoor == true,
                 IsPatio = serviceArea.AdoxioIspatio == true,
                 Capacity = serviceArea.AdoxioCapacity == null ? 0 : serviceArea.AdoxioCapacity,
-                IsTemporaryExtensionArea= serviceArea.AdoxioTemporaryextensionarea.HasValue? serviceArea.AdoxioTemporaryextensionarea.Value:false,
+                IsTemporaryExtensionArea = serviceArea.AdoxioTemporaryextensionarea.HasValue
+                    ? serviceArea.AdoxioTemporaryextensionarea.Value
+                    : false,
+                EndorsementId = serviceArea._adoxioEndorsementValue?.ToString(),
             };
         }
     }

--- a/cllc-public-app/ViewModels/CapacityArea.cs
+++ b/cllc-public-app/ViewModels/CapacityArea.cs
@@ -24,5 +24,6 @@ namespace Gov.Lclb.Cllb.Public.ViewModels
         public bool IsPatio { get; set; }
         public int? Capacity { get; set; }
         public bool IsTemporaryExtensionArea { get; set; }
+        public string EndorsementId { get; set; }
     }
 }


### PR DESCRIPTION
## Ticket

https://jira.justice.gov.bc.ca/browse/LCSD-6680

## Changes

#### The endpoint that returns the licence + endorsement + service area data used by the page has been updated slightly.
- In the array of service area records, it now includes `endorsementId` for the related endorsement (if there is one).
  - This is used to restrict which service area records are available to select in the form.

![image](https://github.com/user-attachments/assets/bba9e357-9e9b-4355-9cba-dae9714c3b56)

#### Updated the related capacity form validation error message to include more details about why the error was triggered.
![image](https://github.com/user-attachments/assets/2bacf37c-4c42-4735-b7d5-cbc7d5d8acba)

#### Added text if the TUA endorsement record has no service areas
![image](https://github.com/user-attachments/assets/9e321ec6-2574-4f07-bceb-7029e4e0832d)

#### Increase allowed number of digits in the attendance field from 4 to 6.
![image](https://github.com/user-attachments/assets/fd5b06d7-ac0e-4813-b10b-7d19a0209b8e)

#### Fixed some html/css display issues for the Event Locations section of the form.

#### Removed some unused css classes.

#### Ran the formatter on touched code.
