### PR TITLE
LCSD-7976-2: Revert SEP Payment Bug Fix

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/sep/sep-application/summary/summary.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/sep/sep-application/summary/summary.component.html
@@ -552,7 +552,7 @@
               <li>Other variations</li>
             </ul>
           </div>
-          <div *ngIf="(getStatus() == 'Payment Required' && (!trnId || trnId === '0')) || mode === 'payNow'">
+          <div *ngIf="(getStatus() == 'Payment Required' && !trnId) || mode === 'payNow'">
             <mat-checkbox [(ngModel)]="isRefundPolicyChecked">
               <span class="error-states">*</span>
               I have read and understand the refund policy.
@@ -626,7 +626,7 @@
         </p>
       </div>
 
-      <section *ngIf="(getStatus() == 'Payment Required' && (!trnId || trnId === '0')) || mode === 'payNow'">
+      <section *ngIf="(getStatus() == 'Payment Required' && !trnId) || mode === 'payNow'">
         <section style="border: solid #ccc 1px; padding: 20px; background-color: #fcba19; padding-bottom: 20px">
           <h3>Application Approved!</h3>
 

--- a/cllc-public-app/ClientApp/src/app/components/sep/sep-application/summary/summary.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/sep/sep-application/summary/summary.component.ts
@@ -132,13 +132,8 @@ export class SummaryComponent implements OnInit {
       });
 
     this.route.queryParams.subscribe((params) => {
-      if (params['trnId']) {
-        this.transactionId = params['trnId'];
-      }
-
-      if (params['SessionKey']) {
-        this.appId = params['SessionKey'];
-      }
+      this.transactionId = params["trnId"];
+      this.appId = params["SessionKey"];
     });
 
     this.route.params.subscribe((params: Params) => {
@@ -153,21 +148,12 @@ export class SummaryComponent implements OnInit {
 
     this.sepDataService.getSpecialEventForApplicant(id).subscribe(async (app) => {
       this.application = app;
-
-      if (!this.transactionId || !this.appId) {
-        // If not already set from query params, set the transactionId and appId from the application, and attempt
-        // to verify payment.
-        this.transactionId = this.application?.invoice?.returnedTransactionId;
-        this.appId = this.application?.id;
-        this.verify_payment();
-      }
-
       this.formatEventDatesForDisplay();
     });
   }
 
   ngOnInit(): void {
-    if (this.transactionId && this.appId) {
+    if (this.transactionId) {
       this.verify_payment();
     }
     window.scrollTo(0, 0);


### PR DESCRIPTION
## Ticket

- https://jira.justice.gov.bc.ca/browse/LCSD-7801
  - PR: https://github.com/bcgov/jag-lcrb-carla-public/pull/4430
- https://jira.justice.gov.bc.ca/browse/LCSD-7976
  - PR: https://github.com/bcgov/jag-lcrb-carla-public/pull/4438


## Changes
- This PR is a follow up to the above 2 linked tickets, and their PRs.
  - It undoes all of the changes from PR #4438.
  - It undoes part of the changes from PR #4430.
    - Specifically, the bit of code around `transactionId`, `trnId`, and the `verify_payments` function.
      - Why? There is an existing bug, that caused the payment details to now be shown, that I tried to fix, but it had some unintended consequences to the "Pay Now" button visibility. A fix will be still be needed for the payment details, but for now we are rolling back these changes in order to fix the "Pay Now" issue (reverting to how the code was before).