### PR TITLE
LCSD-6077: Don't Include Inactive Records on Licence PDF

### DIFF
--- a/cllc-public-app/Controllers/LicensesController.cs
+++ b/cllc-public-app/Controllers/LicensesController.cs
@@ -1281,7 +1281,6 @@ namespace Gov.Lclb.Cllb.Public.Controllers
 
             var expand = new List<string> {
                 "adoxio_Licencee",
-                "adoxio_adoxio_licences_adoxio_applicationtermsconditionslimitation_Licence",
                 "adoxio_adoxio_licences_adoxio_application_AssignedLicence",
                 "adoxio_LicenceType",
                 "adoxio_establishment",
@@ -1310,8 +1309,18 @@ namespace Gov.Lclb.Cllb.Public.Controllers
                     expiraryDateParam = expiryDate.ToString("MMMM dd, yyyy");
                 }
 
+                // Fetch the active terms and conditions for the licence
+                IEnumerable<MicrosoftDynamicsCRMadoxioApplicationtermsconditionslimitation> licenceTermsAndConditions =
+                    _dynamicsClient
+                        .Applicationtermsconditionslimitations.Get(
+                            filter: $"_adoxio_licence_value eq {licenceId} and statecode eq 0",
+                            expand: new List<string> {"adoxio_TermsConditionsPreset"}
+                        )
+                        .Value;
+
+                // Build the human-readable terms and conditions list
                 var termsAndConditions = "";
-                foreach (var item in adoxioLicense.AdoxioAdoxioLicencesAdoxioApplicationtermsconditionslimitationLicence)
+                foreach (var item in licenceTermsAndConditions)
                 {
                     termsAndConditions += $"<li>{item.AdoxioTermsandconditions}</li>";
                 }
@@ -1413,13 +1422,23 @@ namespace Gov.Lclb.Cllb.Public.Controllers
                     {
                         _logger.LogError(e, $"Error loading service areas for {adoxioLicense.AdoxioLicencenumber}");
                     }
-                        //MicrosoftDynamicsCRMadoxioHoursofserviceCollection hours = _dynamicsClient.Hoursofservices.Get(filter: $"_adoxio_licence_value eq {licenceId} and _adoxio_endorsement_value eq null");
+
                         if (allServiceAreas != null && allServiceAreas.Value.Count > 0)
                         {
                             
-                            // sort the areas
-                            IEnumerable<MicrosoftDynamicsCRMadoxioServicearea> serviceAreas = allServiceAreas.Value
+                            IEnumerable<MicrosoftDynamicsCRMadoxioServicearea> filteredServiceAreas = allServiceAreas.Value
+                            // Filter out service areas that should not be printed on the licence
+                            // Context: It appears that the area category field is being utilized to dictate whether or 
+                            // not  a service area should be printed on the licence. In Dynamics, as of July 2025 at 
+                            // least, the field in Dynamics is labelled "Printed On Licence?", and the "Capacity" value 
+                            // is set when the user selects "No" from the dropdown.
                             .Where(area => area.AdoxioAreacategory != (int)ServiceAreaCategoryEnum.Capacity)
+                            // Filter out service areas that have invalid data (possibly a holdover from old data?)
+                            .Where(area => area.AdoxioArealocation != null && area.AdoxioCapacity != null)
+                            // Filter out service areas that are temporary extension areas. A temporary extension area
+                            // is not printed on the licence because it is only relevant for a short period of time.
+                            .Where(area => area.AdoxioTemporaryextensionarea == false)
+                            // Sort the service areas
                             .OrderBy(area => area.AdoxioAreanumber);
 
                             serviceAreaText += $@"<h3 style=""text-align: center;"">CAPACITY</h3>";
@@ -1428,18 +1447,11 @@ namespace Gov.Lclb.Cllb.Public.Controllers
                             var cells = 0;
                             var leftover = 0;
 
-                            foreach (CapacityArea area in licenceVM.ServiceAreas)
+                            foreach (MicrosoftDynamicsCRMadoxioServicearea area in filteredServiceAreas)
                             {
-                                // sometimes we have bad data and should not try to spend our life fixing other people's problems
-                                if (area.AreaLocation == null || area.Capacity == null ||
-                                    area.AreaCategory != 845280000 || area.IsTemporaryExtensionArea == true)
-                                {
-                                    continue;
-                                }
-
                                 cells++;
 
-                                serviceAreaText += $@"<td class='area'><table style='padding:0px; margin: 0px; width:100%; border: 0px solid white;'><tr><td>{area.AreaLocation}</td><td>{area.Capacity}</td></tr></table></td>";
+                                serviceAreaText += $@"<td class='area'><table style='padding:0px; margin: 0px; width:100%; border: 0px solid white;'><tr><td>{area.AdoxioArealocation}</td><td>{area.AdoxioCapacity}</td></tr></table></td>";
 
                                 // every 4 cells
                                 leftover = cells % 4;

--- a/cllc-public-app/ViewModels/Endorsement.cs
+++ b/cllc-public-app/ViewModels/Endorsement.cs
@@ -35,7 +35,7 @@ namespace Gov.Lclb.Cllb.Public.ViewModels
             string htmlVal = "";
 
             // get the hours of service and create a table
-            MicrosoftDynamicsCRMadoxioHoursofserviceCollection hours = _dynamicsClient.Hoursofservices.Get(filter: $"_adoxio_endorsement_value eq {EndorsementId}");
+            MicrosoftDynamicsCRMadoxioHoursofserviceCollection hours = _dynamicsClient.Hoursofservices.Get(filter: $"_adoxio_endorsement_value eq {EndorsementId} and statecode eq 0");
             if (hours.Value.Count > 0)
             {
                 MicrosoftDynamicsCRMadoxioHoursofservice hoursVal = hours.Value.First();
@@ -75,7 +75,7 @@ namespace Gov.Lclb.Cllb.Public.ViewModels
             }
 
             // get the service areas and get their html
-            MicrosoftDynamicsCRMadoxioServiceareaCollection allServiceAreas = _dynamicsClient.Serviceareas.Get(filter: $"_adoxio_endorsement_value eq {EndorsementId}");
+            MicrosoftDynamicsCRMadoxioServiceareaCollection allServiceAreas = _dynamicsClient.Serviceareas.Get(filter: $"_adoxio_endorsement_value eq {EndorsementId} and statecode eq 0");
             if (allServiceAreas.Value.Count > 0)
             {
                 // sort the areas


### PR DESCRIPTION
## Ticket

https://jira.justice.gov.bc.ca/browse/LCSD-6077

## Changes

Fix: Inactive terms and conditions are no longer printed on the Licence.
Fix: Inactive service areas are no longer printed on the licence.
Fix: Inactive store hours are no longer printed on the licence.