### PR TITLE
LCSD-8083-2: TH-UAT-Bug-30

### DIFF
--- a/cllc-interfaces/Dynamics-Autorest/Models/MicrosoftDynamicsCRMadoxioApplicationextension.cs
+++ b/cllc-interfaces/Dynamics-Autorest/Models/MicrosoftDynamicsCRMadoxioApplicationextension.cs
@@ -278,13 +278,13 @@ namespace Gov.Lclb.Cllb.Interfaces.Models
         public System.DateTimeOffset? AdoxioStartdatelicenseactionreq { get; set; }
         
         [JsonProperty(PropertyName = "adoxio_hasliquortiedhouseownershiporcontrol")]
-        public int AdoxioHasLiquorTiedHouseOwnershipOrControl { get; set; }
+        public int? AdoxioHasLiquorTiedHouseOwnershipOrControl { get; set; }
 
         [JsonProperty(PropertyName = "adoxio_hasliquortiedhousethirdpartyassociations")]
-        public int AdoxioHasLiquorTiedHouseThirdPartyAssociations { get; set; }
+        public int? AdoxioHasLiquorTiedHouseThirdPartyAssociations { get; set; }
 
         [JsonProperty(PropertyName = "adoxio_hasliquortiedhousefamilymemberinvolvement")]
-        public int AdoxioHasLiquorTiedHouseFamilyMemberInvolvement { get; set; }
+        public int? AdoxioHasLiquorTiedHouseFamilyMemberInvolvement { get; set; }
 
         [JsonProperty(PropertyName = "adoxio_relatedleorpclapplication")]
         public MicrosoftDynamicsCRMadoxioApplication AdoxioRelatedLeOrPclApplication { get; set; }

--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.ts
@@ -35,6 +35,7 @@ import { TiedHouseConnectionsDataService } from '@services/tied-house-connection
 import { UserDataService } from '@services/user-data.service';
 import { GenericMessageDialogComponent } from '@shared/components/dialog/generic-message-dialog/generic-message-dialog.component';
 import { FormBase } from '@shared/form-base';
+import { isFormValidOrNotTouched } from '@shared/form-utils';
 import { endOfToday } from 'date-fns';
 import { combineLatest, forkJoin, Observable, of, Subscription } from 'rxjs';
 import { catchError, filter, map, switchMap, takeWhile } from 'rxjs/operators';
@@ -613,13 +614,13 @@ export class AccountProfileComponent extends FormBase implements OnInit {
    * Checks if the form is valid.
    *
    * @readonly
-   * @type {boolean} `true` if the form is valid, `false` otherwise.
+   * @type {boolean} `true` if the form is valid or disabled, `false` otherwise.
    */
   get isFormValid(): boolean {
-    return !!(
-      this.form.valid &&
-      this.connectionToProducersComponent?.form?.valid &&
-      this.connectionToOtherLiquorLicencesComponent?.form?.valid
+    return (
+      isFormValidOrNotTouched(this.form) &&
+      isFormValidOrNotTouched(this.connectionToProducersComponent?.form) &&
+      isFormValidOrNotTouched(this.connectionToOtherLiquorLicencesComponent?.form)
     );
   }
 

--- a/cllc-public-app/ClientApp/src/app/components/account-profile/tabs/connection-to-other-liquor-licences/connection-to-other-liquor-licences.component.ts
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/tabs/connection-to-other-liquor-licences/connection-to-other-liquor-licences.component.ts
@@ -7,8 +7,7 @@ import { TiedHouseConnection } from '@models/tied-house-connection.model';
 import { TiedHouseConnectionsDataService } from '@services/tied-house-connections-data.service';
 import { GenericMessageDialogComponent } from '@shared/components/dialog/generic-message-dialog/generic-message-dialog.component';
 import { isValidOrNotTouched } from '@shared/form-utils';
-import { Subject, takeUntil } from 'rxjs';
-import { forkJoin } from 'rxjs/internal/observable/forkJoin';
+import { forkJoin, Subject, takeUntil } from 'rxjs';
 
 export type ConnectionToOtherLiquorLicencesFormData = ApplicationExtension;
 
@@ -92,20 +91,35 @@ export class ConnectionToOtherLiquorLicencesComponent implements OnInit, OnChang
 
   ngOnInit() {
     this.initForm();
-    this.loadFormData();
+    this.initFormInitialData();
     this.loadTiedHouseData();
+    this.setFormMode();
   }
 
   ngOnChanges(changes: SimpleChanges): void {
-    if (changes.application) {
-      this.loadFormData();
+    if (
+      (changes.account &&
+        !changes.account.firstChange &&
+        changes.account.currentValue !== changes.account.previousValue) ||
+      (changes.application &&
+        !changes.application.firstChange &&
+        changes.application.currentValue !== changes.application.previousValue)
+    ) {
+      // If the account or application input changes, re-load the tiedhouse data and update the form mode.
+      this.loadTiedHouseData();
+      this.setFormMode();
     }
 
-    if (changes.account) {
-      this.loadFormData();
+    if (changes.initialFormData && !changes.initialFormData.firstChange && changes.initialFormData.currentValue) {
+      // If the initial form data input changes, re-patch the form data.
+      this.initFormInitialData();
     }
   }
 
+  /**
+   * Initialize the form.
+   * This should only be called once.
+   */
   initForm() {
     this.form = this.fb.group({
       hasLiquorTiedHouseOwnershipOrControl: [null, Validators.required],
@@ -116,13 +130,50 @@ export class ConnectionToOtherLiquorLicencesComponent implements OnInit, OnChang
     this.form.valueChanges.pipe(takeUntil(this.destroy$)).subscribe((value) => this.onFormChanges.emit(value));
   }
 
-  loadFormData() {
-    if (this.initialFormData) {
-      this.form.patchValue(this.initialFormData);
+  /**
+   * Initialize the form with initial data, if any is provided.
+   */
+  initFormInitialData() {
+    if (!this.form) {
+      return;
+    }
+
+    if (!this.initialFormData) {
+      return;
+    }
+
+    this.form.patchValue(this.initialFormData);
+  }
+
+  /**
+   * Set the form mode to either read-only or editable based on the current state.
+   */
+  setFormMode() {
+    if (this.isTiedHouseReadOnly) {
+      // If the tied house component is read-only, disable the form and disable all validators
+      this.form.disable();
+      this.form.get('hasLiquorTiedHouseOwnershipOrControl').clearValidators();
+      this.form.get('hasLiquorTiedHouseThirdPartyAssociations').clearValidators();
+      this.form.get('hasLiquorTiedHouseFamilyMemberInvolvement').clearValidators();
+      this.form.updateValueAndValidity();
+    } else {
+      // If the tied house component is editable, enable the form and set all validators
+      this.form.enable();
+      this.form.get('hasLiquorTiedHouseOwnershipOrControl').setValidators([Validators.required]);
+      this.form.get('hasLiquorTiedHouseThirdPartyAssociations').setValidators([Validators.required]);
+      this.form.get('hasLiquorTiedHouseFamilyMemberInvolvement').setValidators([Validators.required]);
+      this.form.updateValueAndValidity();
     }
   }
 
+  /**
+   * Fetch tied house data for the current account or application.
+   */
   loadTiedHouseData() {
+    if (!this.applicationId && !this.accountId) {
+      return;
+    }
+
     let tiedHouseConnectionsForApplicationIdRequest$ = this.applicationId
       ? this.tiedHouseService.GetLiquorTiedHouseConnectionsForApplication(this.applicationId)
       : this.tiedHouseService.GetLiquorTiedHouseConnectionsForUser(this.accountId);
@@ -212,6 +263,7 @@ export class ConnectionToOtherLiquorLicencesComponent implements OnInit, OnChang
    */
   get isTiedHouseConnectionsEditableForApplication(): boolean {
     if (!this.application) {
+      // If no application is provided, the tied house component is not editable.
       return false;
     }
 
@@ -248,6 +300,11 @@ export class ConnectionToOtherLiquorLicencesComponent implements OnInit, OnChang
    * @return {*}  {boolean}
    */
   isValidOrNotTouched(fieldName: string): boolean {
+    if (this.isTiedHouseReadOnly) {
+      // Mark form fields as valid, if the form is in a read-only state.
+      return true;
+    }
+
     return isValidOrNotTouched(this.form, fieldName);
   }
 

--- a/cllc-public-app/ClientApp/src/app/models/application.model.ts
+++ b/cllc-public-app/ClientApp/src/app/models/application.model.ts
@@ -280,9 +280,9 @@ export interface Application {
 
 export class ApplicationExtension {
   id: string;
-  hasLiquorTiedHouseOwnershipOrControl: number;
-  hasLiquorTiedHouseThirdPartyAssociations: number;
-  hasLiquorTiedHouseFamilyMemberInvolvement: number;
+  hasLiquorTiedHouseOwnershipOrControl: number | null;
+  hasLiquorTiedHouseThirdPartyAssociations: number | null;
+  hasLiquorTiedHouseFamilyMemberInvolvement: number | null;
   /**
    * The ID of a related legal entity or permanent change to a licensee application.
    * - For a legal entity review application, this will be the ID of the permanent change to a licensee application.

--- a/cllc-public-app/ClientApp/src/app/shared/form-utils.ts
+++ b/cllc-public-app/ClientApp/src/app/shared/form-utils.ts
@@ -9,7 +9,30 @@ import { FormGroup } from '@angular/forms';
  * @return {*}  {boolean}
  */
 export function isValidOrNotTouched(form: FormGroup, field: string): boolean {
+  if (!form || !field) {
+    return false;
+  }
+
   const control = form.get(field);
 
+  if (!control) {
+    return false;
+  }
+
   return !!(control?.disabled || control?.valid || !control?.touched);
+}
+
+/**
+ * Returns `true` if the form is disabled, valid, or not touched.
+ *
+ * @export
+ * @param {FormGroup} form
+ * @return {*}  {boolean}
+ */
+export function isFormValidOrNotTouched(form: FormGroup): boolean {
+  if (!form) {
+    return false;
+  }
+
+  return !!(form.disabled || form.valid || !form.touched);
 }

--- a/cllc-public-app/Models.Extensions/ApplicationExtension.cs
+++ b/cllc-public-app/Models.Extensions/ApplicationExtension.cs
@@ -1,7 +1,7 @@
-﻿using Gov.Lclb.Cllb.Interfaces;
+﻿using System.Collections.Generic;
+using Gov.Lclb.Cllb.Interfaces;
 using Gov.Lclb.Cllb.Interfaces.Models;
 using Gov.Lclb.Cllb.Public.ViewModels;
-using System.Collections.Generic;
 
 namespace Gov.Lclb.Cllb.Public.Models
 {
@@ -10,9 +10,10 @@ namespace Gov.Lclb.Cllb.Public.Models
     /// </summary>
     public static class ApplicationTypeExtension
     {
-
-
-        public static void CopyValues(this MicrosoftDynamicsCRMadoxioApplicationextension to, ViewModels.ApplicationExtension from)
+        public static void CopyValues(
+            this MicrosoftDynamicsCRMadoxioApplicationextension to,
+            ViewModels.ApplicationExtension from
+        )
         {
             to.AdoxioApplicationextensionid = from.Id;
             to.AdoxioHasLiquorTiedHouseThirdPartyAssociations = from.HasLiquorTiedHouseThirdPartyAssociations;
@@ -20,7 +21,9 @@ namespace Gov.Lclb.Cllb.Public.Models
             to.AdoxioHasLiquorTiedHouseFamilyMemberInvolvement = from.HasLiquorTiedHouseFamilyMemberInvolvement;
         }
 
-        public static ViewModels.ApplicationExtension ToViewModel(this MicrosoftDynamicsCRMadoxioApplicationextension applicationExtension)
+        public static ViewModels.ApplicationExtension ToViewModel(
+            this MicrosoftDynamicsCRMadoxioApplicationextension applicationExtension
+        )
         {
             ViewModels.ApplicationExtension result = null;
             if (applicationExtension != null)
@@ -28,15 +31,16 @@ namespace Gov.Lclb.Cllb.Public.Models
                 result = new ApplicationExtension
                 {
                     Id = applicationExtension.AdoxioApplicationextensionid,
-                    HasLiquorTiedHouseThirdPartyAssociations = applicationExtension.AdoxioHasLiquorTiedHouseThirdPartyAssociations,
-                    HasLiquorTiedHouseOwnershipOrControl = applicationExtension.AdoxioHasLiquorTiedHouseOwnershipOrControl,
-                    HasLiquorTiedHouseFamilyMemberInvolvement = applicationExtension.AdoxioHasLiquorTiedHouseFamilyMemberInvolvement,
+                    HasLiquorTiedHouseThirdPartyAssociations =
+                        applicationExtension.AdoxioHasLiquorTiedHouseThirdPartyAssociations,
+                    HasLiquorTiedHouseOwnershipOrControl =
+                        applicationExtension.AdoxioHasLiquorTiedHouseOwnershipOrControl,
+                    HasLiquorTiedHouseFamilyMemberInvolvement =
+                        applicationExtension.AdoxioHasLiquorTiedHouseFamilyMemberInvolvement,
                     RelatedLeOrPclApplicationId = applicationExtension._adoxioRelatedLeOrPclApplicationValue
                 };
             }
             return result;
         }
-
     }
 }
-

--- a/cllc-public-app/ViewModels/Application.cs
+++ b/cllc-public-app/ViewModels/Application.cs
@@ -809,9 +809,9 @@ namespace Gov.Lclb.Cllb.Public.ViewModels
     public class ApplicationExtension
     {
         public string Id { get; set; }
-        public int HasLiquorTiedHouseOwnershipOrControl { get; set; }
-        public int HasLiquorTiedHouseThirdPartyAssociations { get; set; }
-        public int HasLiquorTiedHouseFamilyMemberInvolvement { get; set; }
+        public int? HasLiquorTiedHouseOwnershipOrControl { get; set; }
+        public int? HasLiquorTiedHouseThirdPartyAssociations { get; set; }
+        public int? HasLiquorTiedHouseFamilyMemberInvolvement { get; set; }
 
         /// <summary>
         /// The ID of a related legal entity or permanent change to a licensee application.


### PR DESCRIPTION
## Ticket

https://jira.justice.gov.bc.ca/browse/LCSD-8083

## Changes

- Fix validation issue, where the connection-to-other-liquor-licences form fields were always required, even when in a read-only state.
- Update application extension, allow 3 radio fields to default to "null" if unset. The business wants the frontend to display the radio controls as empty (so they have to choose either "yes" or "no).