### PR TITLE
Add CI workflows and Dockerfiles for multiple services

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+**/bin
+**/obj
+**/*.user
+**/*.suo
+cllc-public-app/ClientApp/node_modules
+cllc-public-app/ClientApp/dist
+cllc-public-app/ClientApp/.angular
+cllc-public-app/ClientApp/coverage

--- a/.github/workflows/ci-build-all-gha.yml
+++ b/.github/workflows/ci-build-all-gha.yml
@@ -1,0 +1,45 @@
+name: Build and Deploy All GHA Services
+
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Branch to build (defaults to dv-migration)'
+        required: false
+        default: dv-migration
+
+jobs:
+  trigger-all:
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+
+    steps:
+      - name: Trigger all CI workflows
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REF: ${{ inputs.ref || 'dv-migration' }}
+        run: |
+          WORKFLOWS=(
+            ci-geocoder-service-gha.yml
+            ci-pdf-service-gha.yml
+            ci-federal-reporting-service-gha.yml
+            ci-file-manager-service-gha.yml
+            ci-one-stop-service-gha.yml
+            ci-orgbook-service-gha.yml
+            ci-carla-spice-sync-service-gha.yml
+            ci-cllc-public-api-gha.yml
+            ci-cllc-public-frontend-gha.yml
+          )
+
+          for workflow in "${WORKFLOWS[@]}"; do
+            echo "Triggering $workflow on $REF ..."
+            gh workflow run "$workflow" \
+              --repo "${{ github.repository }}" \
+              --ref "$REF"
+            sleep 2  # avoid GitHub API rate limit
+          done
+
+          echo ""
+          echo "All 9 workflows triggered on branch: $REF"
+          echo "Monitor runs at: https://github.com/${{ github.repository }}/actions"

--- a/.github/workflows/ci-carla-spice-sync-service-gha.yml
+++ b/.github/workflows/ci-carla-spice-sync-service-gha.yml
@@ -1,0 +1,66 @@
+name: CI - carla-spice-sync-service-gha
+
+on:
+  push:
+    branches: [dv-migration]
+    paths:
+      - 'carla-spice-sync-service/**'
+      - 'cllc-interfaces/SharePoint/**'
+      - 'cllc-interfaces/SPICE/**'
+      - 'cllc-interfaces/Dynamics-Dataverse/**'
+      - '.github/workflows/ci-carla-spice-sync-service-gha.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/bcgov/jag-lcrb-carla-public/carla-spice-sync-service-gha
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set environment tag
+        id: env-tag
+        run: |
+          case "${{ github.ref_name }}" in
+            develop)      echo "ENV_TAG=dev"         >> $GITHUB_OUTPUT ;;
+            test)         echo "ENV_TAG=test"        >> $GITHUB_OUTPUT ;;
+            master)       echo "ENV_TAG=prod"        >> $GITHUB_OUTPUT ;;
+            dv-migration) echo "ENV_TAG=sandbox-dev" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: ./carla-spice-sync-service/Dockerfile.gha
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/bcgov/jag-lcrb-carla-public
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+
+      - name: Trigger deployment
+        if: success() && steps.env-tag.outputs.ENV_TAG != ''
+        uses: peter-evans/repository-dispatch@v3  # TODO: pin to commit SHA after first run
+        with:
+          token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
+          repository: bcgov-c/lcrb-carla-pipelines
+          event-type: deploy
+          client-payload: '{"service":"carla-spice-sync-service","env":"${{ steps.env-tag.outputs.ENV_TAG }}","image":"${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}"}'

--- a/.github/workflows/ci-cllc-public-api-gha.yml
+++ b/.github/workflows/ci-cllc-public-api-gha.yml
@@ -1,0 +1,64 @@
+name: CI - cllc-public-api-gha
+
+on:
+  push:
+    branches: [dv-migration]
+    paths:
+      - 'cllc-public-app/**'
+      - 'cllc-interfaces/**'
+      - '.github/workflows/ci-cllc-public-api-gha.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/bcgov/jag-lcrb-carla-public/cllc-public-api-gha
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set environment tag
+        id: env-tag
+        run: |
+          case "${{ github.ref_name }}" in
+            develop)      echo "ENV_TAG=dev"         >> $GITHUB_OUTPUT ;;
+            test)         echo "ENV_TAG=test"        >> $GITHUB_OUTPUT ;;
+            master)       echo "ENV_TAG=prod"        >> $GITHUB_OUTPUT ;;
+            dv-migration) echo "ENV_TAG=sandbox-dev" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: ./cllc-public-app/Dockerfile.gha
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/bcgov/jag-lcrb-carla-public
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+
+      - name: Trigger deployment
+        if: success() && steps.env-tag.outputs.ENV_TAG != ''
+        uses: peter-evans/repository-dispatch@v3  # TODO: pin to commit SHA after first run
+        with:
+          token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
+          repository: bcgov-c/lcrb-carla-pipelines
+          event-type: deploy
+          client-payload: '{"service":"cllc-public-app","env":"${{ steps.env-tag.outputs.ENV_TAG }}","image":"${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}"}'

--- a/.github/workflows/ci-cllc-public-frontend-gha.yml
+++ b/.github/workflows/ci-cllc-public-frontend-gha.yml
@@ -1,0 +1,71 @@
+name: CI - cllc-public-frontend-gha
+
+on:
+  push:
+    branches: [dv-migration]
+    paths:
+      - 'cllc-public-app/ClientApp/**'
+      - 'cllc-public-app/Dockerfile.frontend.gha'
+      - 'cllc-public-app/nginx.conf.gha'
+      - '.github/workflows/ci-cllc-public-frontend-gha.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/bcgov/jag-lcrb-carla-public/cllc-public-frontend-gha
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set environment tag and build script
+        id: env-tag
+        run: |
+          case "${{ github.ref_name }}" in
+            develop)      echo "ENV_TAG=dev"         >> $GITHUB_OUTPUT
+                          echo "BUILD_SCRIPT=build"     >> $GITHUB_OUTPUT ;;
+            test)         echo "ENV_TAG=test"        >> $GITHUB_OUTPUT
+                          echo "BUILD_SCRIPT=build"     >> $GITHUB_OUTPUT ;;
+            master)       echo "ENV_TAG=prod"        >> $GITHUB_OUTPUT
+                          echo "BUILD_SCRIPT=buildprod" >> $GITHUB_OUTPUT ;;
+            dv-migration) echo "ENV_TAG=sandbox-dev" >> $GITHUB_OUTPUT
+                          echo "BUILD_SCRIPT=build"     >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: ./cllc-public-app
+          file: ./cllc-public-app/Dockerfile.frontend.gha
+          push: true
+          build-args: |
+            BUILD_SCRIPT=${{ steps.env-tag.outputs.BUILD_SCRIPT }}
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/bcgov/jag-lcrb-carla-public
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+
+      - name: Trigger deployment
+        if: success() && steps.env-tag.outputs.ENV_TAG != ''
+        uses: peter-evans/repository-dispatch@v3  # TODO: pin to commit SHA after first run
+        with:
+          token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
+          repository: bcgov-c/lcrb-carla-pipelines
+          event-type: deploy
+          client-payload: '{"service":"cllc-public-frontend","env":"${{ steps.env-tag.outputs.ENV_TAG }}","image":"${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}"}'

--- a/.github/workflows/ci-federal-reporting-service-gha.yml
+++ b/.github/workflows/ci-federal-reporting-service-gha.yml
@@ -1,0 +1,64 @@
+name: CI - federal-reporting-service-gha
+
+on:
+  push:
+    branches: [dv-migration]
+    paths:
+      - 'federal-reporting-service/**'
+      - 'cllc-interfaces/Dynamics-Dataverse/**'
+      - '.github/workflows/ci-federal-reporting-service-gha.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/bcgov/jag-lcrb-carla-public/federal-reporting-service-gha
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set environment tag
+        id: env-tag
+        run: |
+          case "${{ github.ref_name }}" in
+            develop)      echo "ENV_TAG=dev"         >> $GITHUB_OUTPUT ;;
+            test)         echo "ENV_TAG=test"        >> $GITHUB_OUTPUT ;;
+            master)       echo "ENV_TAG=prod"        >> $GITHUB_OUTPUT ;;
+            dv-migration) echo "ENV_TAG=sandbox-dev" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: ./federal-reporting-service/Dockerfile.gha
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/bcgov/jag-lcrb-carla-public
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+
+      - name: Trigger deployment
+        if: success() && steps.env-tag.outputs.ENV_TAG != ''
+        uses: peter-evans/repository-dispatch@v3  # TODO: pin to commit SHA after first run
+        with:
+          token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
+          repository: bcgov-c/lcrb-carla-pipelines
+          event-type: deploy
+          client-payload: '{"service":"federal-reporting-service","env":"${{ steps.env-tag.outputs.ENV_TAG }}","image":"${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}"}'

--- a/.github/workflows/ci-file-manager-service-gha.yml
+++ b/.github/workflows/ci-file-manager-service-gha.yml
@@ -1,0 +1,64 @@
+name: CI - file-manager-service-gha
+
+on:
+  push:
+    branches: [dv-migration]
+    paths:
+      - 'file-manager-service/**'
+      - 'cllc-interfaces/SharePoint/**'
+      - '.github/workflows/ci-file-manager-service-gha.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/bcgov/jag-lcrb-carla-public/file-manager-service-gha
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set environment tag
+        id: env-tag
+        run: |
+          case "${{ github.ref_name }}" in
+            develop)      echo "ENV_TAG=dev"         >> $GITHUB_OUTPUT ;;
+            test)         echo "ENV_TAG=test"        >> $GITHUB_OUTPUT ;;
+            master)       echo "ENV_TAG=prod"        >> $GITHUB_OUTPUT ;;
+            dv-migration) echo "ENV_TAG=sandbox-dev" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: ./file-manager-service/Dockerfile.gha
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/bcgov/jag-lcrb-carla-public
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+
+      - name: Trigger deployment
+        if: success() && steps.env-tag.outputs.ENV_TAG != ''
+        uses: peter-evans/repository-dispatch@v3  # TODO: pin to commit SHA after first run
+        with:
+          token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
+          repository: bcgov-c/lcrb-carla-pipelines
+          event-type: deploy
+          client-payload: '{"service":"file-manager-service","env":"${{ steps.env-tag.outputs.ENV_TAG }}","image":"${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}"}'

--- a/.github/workflows/ci-geocoder-service-gha.yml
+++ b/.github/workflows/ci-geocoder-service-gha.yml
@@ -1,0 +1,64 @@
+name: CI - geocoder-service-gha
+
+on:
+  push:
+    branches: [dv-migration]
+    paths:
+      - 'geocoder-service/**'
+      - 'cllc-interfaces/**'
+      - '.github/workflows/ci-geocoder-service-gha.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/bcgov/jag-lcrb-carla-public/geocoder-service-gha
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set environment tag
+        id: env-tag
+        run: |
+          case "${{ github.ref_name }}" in
+            develop)      echo "ENV_TAG=dev"         >> $GITHUB_OUTPUT ;;
+            test)         echo "ENV_TAG=test"        >> $GITHUB_OUTPUT ;;
+            master)       echo "ENV_TAG=prod"        >> $GITHUB_OUTPUT ;;
+            dv-migration) echo "ENV_TAG=sandbox-dev" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: ./geocoder-service/Dockerfile.gha
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/bcgov/jag-lcrb-carla-public
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+
+      - name: Trigger deployment
+        if: success() && steps.env-tag.outputs.ENV_TAG != ''
+        uses: peter-evans/repository-dispatch@v3  # TODO: pin to commit SHA after first run
+        with:
+          token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
+          repository: bcgov-c/lcrb-carla-pipelines
+          event-type: deploy
+          client-payload: '{"service":"geocoder-service","env":"${{ steps.env-tag.outputs.ENV_TAG }}","image":"${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}"}'

--- a/.github/workflows/ci-one-stop-service-gha.yml
+++ b/.github/workflows/ci-one-stop-service-gha.yml
@@ -1,0 +1,65 @@
+name: CI - one-stop-service-gha
+
+on:
+  push:
+    branches: [dv-migration]
+    paths:
+      - 'one-stop-service/**'
+      - 'cllc-interfaces/OneStopRestClient/**'
+      - 'cllc-interfaces/Dynamics-Dataverse/**'
+      - '.github/workflows/ci-one-stop-service-gha.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/bcgov/jag-lcrb-carla-public/one-stop-service-gha
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set environment tag
+        id: env-tag
+        run: |
+          case "${{ github.ref_name }}" in
+            develop)      echo "ENV_TAG=dev"         >> $GITHUB_OUTPUT ;;
+            test)         echo "ENV_TAG=test"        >> $GITHUB_OUTPUT ;;
+            master)       echo "ENV_TAG=prod"        >> $GITHUB_OUTPUT ;;
+            dv-migration) echo "ENV_TAG=sandbox-dev" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: ./one-stop-service/Dockerfile.gha
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/bcgov/jag-lcrb-carla-public
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+
+      - name: Trigger deployment
+        if: success() && steps.env-tag.outputs.ENV_TAG != ''
+        uses: peter-evans/repository-dispatch@v3  # TODO: pin to commit SHA after first run
+        with:
+          token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
+          repository: bcgov-c/lcrb-carla-pipelines
+          event-type: deploy
+          client-payload: '{"service":"one-stop-service","env":"${{ steps.env-tag.outputs.ENV_TAG }}","image":"${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}"}'

--- a/.github/workflows/ci-orgbook-service-gha.yml
+++ b/.github/workflows/ci-orgbook-service-gha.yml
@@ -1,0 +1,64 @@
+name: CI - orgbook-service-gha
+
+on:
+  push:
+    branches: [dv-migration]
+    paths:
+      - 'orgbook-service/**'
+      - 'cllc-interfaces/Dynamics-Dataverse/**'
+      - '.github/workflows/ci-orgbook-service-gha.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/bcgov/jag-lcrb-carla-public/orgbook-service-gha
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set environment tag
+        id: env-tag
+        run: |
+          case "${{ github.ref_name }}" in
+            develop)      echo "ENV_TAG=dev"         >> $GITHUB_OUTPUT ;;
+            test)         echo "ENV_TAG=test"        >> $GITHUB_OUTPUT ;;
+            master)       echo "ENV_TAG=prod"        >> $GITHUB_OUTPUT ;;
+            dv-migration) echo "ENV_TAG=sandbox-dev" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: ./orgbook-service/Dockerfile.gha
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/bcgov/jag-lcrb-carla-public
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+
+      - name: Trigger deployment
+        if: success() && steps.env-tag.outputs.ENV_TAG != ''
+        uses: peter-evans/repository-dispatch@v3  # TODO: pin to commit SHA after first run
+        with:
+          token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
+          repository: bcgov-c/lcrb-carla-pipelines
+          event-type: deploy
+          client-payload: '{"service":"orgbook-service","env":"${{ steps.env-tag.outputs.ENV_TAG }}","image":"${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}"}'

--- a/.github/workflows/ci-pdf-service-gha.yml
+++ b/.github/workflows/ci-pdf-service-gha.yml
@@ -1,0 +1,63 @@
+name: CI - pdf-service-gha
+
+on:
+  push:
+    branches: [dv-migration]
+    paths:
+      - 'pdf-service/**'
+      - '.github/workflows/ci-pdf-service-gha.yml'
+  workflow_dispatch:
+
+env:
+  IMAGE_NAME: ghcr.io/bcgov/jag-lcrb-carla-public/pdf-service-gha
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set environment tag
+        id: env-tag
+        run: |
+          case "${{ github.ref_name }}" in
+            develop)      echo "ENV_TAG=dev"         >> $GITHUB_OUTPUT ;;
+            test)         echo "ENV_TAG=test"        >> $GITHUB_OUTPUT ;;
+            master)       echo "ENV_TAG=prod"        >> $GITHUB_OUTPUT ;;
+            dv-migration) echo "ENV_TAG=sandbox-dev" >> $GITHUB_OUTPUT ;;
+          esac
+
+      - name: Log in to GitHub Container Registry
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push image
+        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 # v6.10.0
+        with:
+          context: .
+          file: ./pdf-service/Dockerfile.gha
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}
+            ${{ env.IMAGE_NAME }}:sha-${{ github.sha }}
+          labels: |
+            org.opencontainers.image.source=https://github.com/bcgov/jag-lcrb-carla-public
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.ref.name=${{ github.ref_name }}
+
+      - name: Trigger deployment
+        if: success() && steps.env-tag.outputs.ENV_TAG != ''
+        uses: peter-evans/repository-dispatch@v3  # TODO: pin to commit SHA after first run
+        with:
+          token: ${{ secrets.DEPLOY_TRIGGER_TOKEN }}
+          repository: bcgov-c/lcrb-carla-pipelines
+          event-type: deploy
+          client-payload: '{"service":"pdf-service","env":"${{ steps.env-tag.outputs.ENV_TAG }}","image":"${{ env.IMAGE_NAME }}:${{ steps.env-tag.outputs.ENV_TAG }}"}'

--- a/carla-spice-sync-service/Dockerfile.gha
+++ b/carla-spice-sync-service/Dockerfile.gha
@@ -1,0 +1,28 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY ["carla-spice-sync-service/CarlaSpiceSync.csproj", "carla-spice-sync-service/"]
+COPY ["cllc-interfaces/SharePoint/SharePoint.csproj", "cllc-interfaces/SharePoint/"]
+COPY ["cllc-interfaces/SPICE/SpiceClient.csproj", "cllc-interfaces/SPICE/"]
+COPY ["cllc-interfaces/Dynamics-Dataverse/Dynamics-Dataverse.csproj", "cllc-interfaces/Dynamics-Dataverse/"]
+
+RUN dotnet restore "carla-spice-sync-service/CarlaSpiceSync.csproj"
+
+COPY carla-spice-sync-service/ carla-spice-sync-service/
+COPY cllc-interfaces/ cllc-interfaces/
+
+WORKDIR "/src/carla-spice-sync-service"
+RUN dotnet build "CarlaSpiceSync.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "CarlaSpiceSync.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "CarlaSpiceSync.dll"]

--- a/cllc-public-app/.dockerignore
+++ b/cllc-public-app/.dockerignore
@@ -1,0 +1,8 @@
+ClientApp/node_modules
+ClientApp/dist
+ClientApp/.angular
+ClientApp/coverage
+**/*.user
+**/*.suo
+**/bin
+**/obj

--- a/cllc-public-app/Dockerfile.frontend.gha
+++ b/cllc-public-app/Dockerfile.frontend.gha
@@ -1,0 +1,36 @@
+### Stage 1 — Build Angular app
+FROM node:18-alpine AS builder
+WORKDIR /app
+
+# build arg controls dev/test vs prod base-href
+# develop/test → build (base-href /lcrb/)
+# master       → buildprod (base-href /)
+ARG BUILD_SCRIPT=build
+
+COPY ClientApp/package*.json ./
+RUN npm ci --legacy-peer-deps
+
+COPY ClientApp/ .
+RUN npm run ${BUILD_SCRIPT}
+
+### Stage 2 — nginx to serve static files
+FROM nginx:1.25-alpine AS final
+
+# OpenShift runs containers as an arbitrary UID with GID=0 (root group).
+# chown to nginx:root so g+rw grants write to OpenShift's GID=0 process.
+RUN touch /tmp/nginx.pid && \
+    chown -R nginx:root /var/cache/nginx /var/log/nginx /usr/share/nginx/html && \
+    chmod -R g+rw /var/cache/nginx /var/log/nginx /usr/share/nginx/html && \
+    mkdir -p /tmp/client_body /tmp/proxy /tmp/fastcgi /tmp/uwsgi /tmp/scgi && \
+    chmod -R 777 /tmp
+
+COPY --from=builder /app/dist/ /usr/share/nginx/html/
+COPY nginx.conf.gha /etc/nginx/nginx.conf
+
+# Ensure copied files are also group-writable for OpenShift arbitrary UID
+RUN chown -R nginx:root /usr/share/nginx/html && chmod -R g+rw /usr/share/nginx/html
+
+EXPOSE 8080
+USER nginx
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/cllc-public-app/Dockerfile.gha
+++ b/cllc-public-app/Dockerfile.gha
@@ -1,0 +1,33 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY ["cllc-public-app/cllc-public-app.csproj", "cllc-public-app/"]
+COPY ["cllc-interfaces/BCeID/BCeID.csproj", "cllc-interfaces/BCeID/"]
+COPY ["cllc-interfaces/BCEP/BCEP.csproj", "cllc-interfaces/BCEP/"]
+COPY ["cllc-interfaces/GeocoderClient/Geocoder.csproj", "cllc-interfaces/GeocoderClient/"]
+COPY ["cllc-interfaces/SharePoint/SharePoint.csproj", "cllc-interfaces/SharePoint/"]
+COPY ["cllc-interfaces/OrgBookClient/OrgBookClient.csproj", "cllc-interfaces/OrgBookClient/"]
+COPY ["cllc-interfaces/PDF/PDF.csproj", "cllc-interfaces/PDF/"]
+COPY ["cllc-interfaces/Dynamics-Dataverse/Dynamics-Dataverse.csproj", "cllc-interfaces/Dynamics-Dataverse/"]
+
+RUN dotnet restore "cllc-public-app/cllc-public-app.csproj"
+
+COPY cllc-public-app/ cllc-public-app/
+COPY cllc-interfaces/ cllc-interfaces/
+COPY file-manager-service/Protos/ file-manager-service/Protos/
+
+WORKDIR "/src/cllc-public-app"
+RUN dotnet build "cllc-public-app.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "cllc-public-app.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "cllc-public-app.dll"]

--- a/cllc-public-app/nginx.conf.gha
+++ b/cllc-public-app/nginx.conf.gha
@@ -1,0 +1,100 @@
+worker_processes auto;
+
+error_log /var/log/nginx/error.log warn;
+pid       /tmp/nginx.pid;
+
+events {
+    worker_connections 4096;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    server_tokens off;
+
+    client_max_body_size 100M;
+
+    proxy_connect_timeout 600;
+    proxy_send_timeout    600;
+    proxy_read_timeout    600;
+    send_timeout          600;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    # allow nginx to run as non-root
+    client_body_temp_path /tmp/client_body;
+    proxy_temp_path       /tmp/proxy;
+    fastcgi_temp_path     /tmp/fastcgi;
+    uwsgi_temp_path       /tmp/uwsgi;
+    scgi_temp_path        /tmp/scgi;
+
+    server {
+        listen 8080;
+        server_name localhost;
+
+        add_header Content-Security-Policy "default-src * data: blob: filesystem: 'unsafe-inline' 'unsafe-eval'";
+        add_header Strict-Transport-Security "max-age=86400; includeSubDomains";
+        add_header X-Content-Type-Options "nosniff";
+        add_header X-XSS-Protection 1;
+        add_header X-Frame-Options DENY;
+
+        # rewrite /lcrb prefix for dev/test builds
+        rewrite ^/lcrb[^/]*/(.*) /$1 last;
+
+        # proxy API and auth paths to the .NET backend service
+        location /api {
+            proxy_pass         http://cllc-public-app-gha:8080;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        location /login {
+            proxy_pass         http://cllc-public-app-gha:8080;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        location /logout {
+            proxy_pass         http://cllc-public-app-gha:8080;
+            proxy_set_header   Host              $host;
+            proxy_set_header   X-Real-IP         $remote_addr;
+            proxy_set_header   X-Forwarded-For   $proxy_add_x_forwarded_for;
+            proxy_set_header   X-Forwarded-Proto $scheme;
+        }
+
+        location /hc {
+            proxy_pass http://cllc-public-app-gha:8080;
+        }
+
+        location / {
+            root  /usr/share/nginx/html;
+            index index.html index.htm;
+            try_files $uri /index.html;
+            gzip on;
+            gzip_min_length 1000;
+            gzip_types *;
+        }
+
+        location /nginx_status {
+            stub_status on;
+            allow all;
+            access_log off;
+        }
+
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+            root /usr/share/nginx/html;
+        }
+    }
+}

--- a/cllc-public-app/nginx.conf.local
+++ b/cllc-public-app/nginx.conf.local
@@ -1,0 +1,92 @@
+worker_processes auto;
+
+error_log /var/log/nginx/error.log warn;
+pid       /tmp/nginx.pid;
+
+events {
+    worker_connections 4096;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    server_tokens off;
+
+    client_max_body_size 100M;
+
+    proxy_connect_timeout 600;
+    proxy_send_timeout    600;
+    proxy_read_timeout    600;
+    send_timeout          600;
+
+    log_format main '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log /var/log/nginx/access.log main;
+
+    sendfile on;
+    keepalive_timeout 65;
+
+    client_body_temp_path /tmp/client_body;
+    proxy_temp_path       /tmp/proxy;
+    fastcgi_temp_path     /tmp/fastcgi;
+    uwsgi_temp_path       /tmp/uwsgi;
+    scgi_temp_path        /tmp/scgi;
+
+    server {
+        listen 8080;
+        server_name localhost;
+
+        add_header Content-Security-Policy "default-src * data: blob: filesystem: 'unsafe-inline' 'unsafe-eval'";
+        add_header X-Content-Type-Options "nosniff";
+
+        rewrite ^/lcrb[^/]*/(.*) /$1 last;
+
+        # Proxy all .NET backend routes
+        location /api {
+            proxy_pass         http://backend:8080;
+            proxy_http_version 1.1;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /login {
+            proxy_pass         http://backend:8080;
+            proxy_http_version 1.1;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /logout {
+            proxy_pass         http://backend:8080;
+            proxy_http_version 1.1;
+            proxy_set_header   Host $host;
+            proxy_set_header   X-Real-IP $remote_addr;
+            proxy_set_header   X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        location /hc {
+            proxy_pass         http://backend:8080;
+            proxy_http_version 1.1;
+            proxy_set_header   Host $host;
+        }
+
+        # Serve Angular SPA for everything else
+        location / {
+            root  /usr/share/nginx/html;
+            index index.html index.htm;
+            try_files $uri /index.html;
+            gzip on;
+            gzip_min_length 1000;
+            gzip_types *;
+        }
+
+        error_page 500 502 503 504 /50x.html;
+        location = /50x.html {
+            root /usr/share/nginx/html;
+        }
+    }
+}

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,25 @@
+services:
+
+  backend:
+    image: cllc-public-api-gha:local
+    environment:
+      - ASPNETCORE_ENVIRONMENT=Development
+    volumes:
+      - ${APPDATA}/Microsoft/UserSecrets:/root/.microsoft/usersecrets:ro
+    networks:
+      - app
+
+  frontend:
+    image: cllc-public-frontend-gha:local
+    ports:
+      - "8080:8080"
+    volumes:
+      - ./cllc-public-app/nginx.conf.local:/etc/nginx/nginx.conf:ro
+    networks:
+      - app
+    depends_on:
+      - backend
+
+networks:
+  app:
+    driver: bridge

--- a/federal-reporting-service/Dockerfile.gha
+++ b/federal-reporting-service/Dockerfile.gha
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY ["federal-reporting-service/federal-reporting-service.csproj", "federal-reporting-service/"]
+COPY ["cllc-interfaces/Dynamics-Dataverse/Dynamics-Dataverse.csproj", "cllc-interfaces/Dynamics-Dataverse/"]
+
+RUN dotnet restore "federal-reporting-service/federal-reporting-service.csproj"
+
+COPY federal-reporting-service/ federal-reporting-service/
+COPY cllc-interfaces/ cllc-interfaces/
+COPY file-manager-service/Protos/ file-manager-service/Protos/
+
+WORKDIR "/src/federal-reporting-service"
+RUN dotnet build "federal-reporting-service.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "federal-reporting-service.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "federal-reporting-service.dll"]

--- a/federal-reporting-service/Startup.cs
+++ b/federal-reporting-service/Startup.cs
@@ -32,15 +32,13 @@ namespace Gov.Lclb.Cllb.FederalReportingService
 {
     public class Startup
     {
-        private readonly ILoggerFactory _loggerFactory;
         public IConfiguration Configuration { get; }
         public IWebHostEnvironment _env { get; set; }
         public FileManagerClient _fileManagerClient { get; set; }
 
-        public Startup(IWebHostEnvironment env, ILoggerFactory loggerFactory)
+        public Startup(IWebHostEnvironment env)
         {
             _env = env;
-            _loggerFactory = loggerFactory;
 
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
@@ -60,7 +58,9 @@ namespace Gov.Lclb.Cllb.FederalReportingService
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<Microsoft.Extensions.Logging.ILogger>(_loggerFactory.CreateLogger("FederalReportingService"));
+            services.AddSingleton<Microsoft.Extensions.Logging.ILogger>(sp =>
+                sp.GetService<Microsoft.Extensions.Logging.ILoggerFactory>()?.CreateLogger("FederalReportingService")
+                ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
 
             services.AddHangfire(config =>
             {
@@ -97,27 +97,32 @@ namespace Gov.Lclb.Cllb.FederalReportingService
                 httpClient.DefaultRequestVersion = HttpVersion.Version20;
               
                 var initialChannel = GrpcChannel.ForAddress(fileManagerURI, new GrpcChannelOptions { HttpClient = httpClient });
-                
+
                 var initialClient = new FileManagerClient(initialChannel);
-                // call the token service to get a token.
                 var tokenRequest = new TokenRequest()
                 {
                     Secret = Configuration["FILE_MANAGER_SECRET"]
                 };
 
-                var tokenReply = initialClient.GetToken(tokenRequest);
-
-                if (tokenReply != null && tokenReply.ResultStatus == ResultStatus.Success)
+                try
                 {
-                    // Add the bearer token to the client.
-                    
-                    httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {tokenReply.Token}");
+                    var tokenReply = initialClient.GetToken(tokenRequest);
 
-                    var channel = GrpcChannel.ForAddress(fileManagerURI, new GrpcChannelOptions() { HttpClient = httpClient });                   
-                    _fileManagerClient = new FileManagerClient(channel);
-                    services.AddTransient<FileManagerClient>(_ => _fileManagerClient);
-
+                    if (tokenReply != null && tokenReply.ResultStatus == ResultStatus.Success)
+                    {
+                        httpClient.DefaultRequestHeaders.Add("Authorization", $"Bearer {tokenReply.Token}");
+                        var channel = GrpcChannel.ForAddress(fileManagerURI, new GrpcChannelOptions() { HttpClient = httpClient });
+                        _fileManagerClient = new FileManagerClient(channel);
+                    }
                 }
+                catch (Exception ex)
+                {
+                    // file-manager not ready at startup — jobs will fail gracefully when they run
+                    Console.WriteLine($"[federal-reporting] Could not connect to file-manager at startup: {ex.Message}");
+                }
+
+                // always register so DI doesn't throw; null client is guarded inside job handlers
+                services.AddTransient<FileManagerClient>(_ => _fileManagerClient);
             }
             services.AddSingleton<IDataverseClient, DataverseClient>();
         }

--- a/file-manager-service/Dockerfile.gha
+++ b/file-manager-service/Dockerfile.gha
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY ["file-manager-service/file-manager-service.csproj", "file-manager-service/"]
+COPY ["cllc-interfaces/SharePoint/SharePoint.csproj", "cllc-interfaces/SharePoint/"]
+
+RUN dotnet restore "file-manager-service/file-manager-service.csproj"
+
+COPY file-manager-service/ file-manager-service/
+COPY cllc-interfaces/ cllc-interfaces/
+
+WORKDIR "/src/file-manager-service"
+RUN dotnet build "file-manager-service.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "file-manager-service.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "file-manager-service.dll"]

--- a/geocoder-service/Dockerfile.gha
+++ b/geocoder-service/Dockerfile.gha
@@ -1,0 +1,29 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+# Copy project files first for layer caching on restore
+COPY ["geocoder-service/geocoder-service.csproj", "geocoder-service/"]
+COPY ["cllc-interfaces/GeoCoder/Geocoder.csproj", "cllc-interfaces/GeoCoder/"]
+COPY ["cllc-interfaces/Dynamics-Dataverse/Dynamics-Dataverse.csproj", "cllc-interfaces/Dynamics-Dataverse/"]
+
+RUN dotnet restore "geocoder-service/geocoder-service.csproj"
+
+# Copy source
+COPY geocoder-service/ geocoder-service/
+COPY cllc-interfaces/ cllc-interfaces/
+
+WORKDIR "/src/geocoder-service"
+RUN dotnet build "geocoder-service.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "geocoder-service.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "geocoder-service.dll"]

--- a/geocoder-service/Startup.cs
+++ b/geocoder-service/Startup.cs
@@ -35,11 +35,8 @@ namespace Gov.Lclb.Cllb.Geocoder
 {
     public class Startup
     {
-        private readonly ILoggerFactory _loggerFactory;
-
-        public Startup(IConfiguration configuration, ILoggerFactory loggerFactory)
+        public Startup(IConfiguration configuration)
         {
-            _loggerFactory = loggerFactory;
             Configuration = configuration;
         }
 
@@ -49,7 +46,8 @@ namespace Gov.Lclb.Cllb.Geocoder
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddSingleton<Microsoft.Extensions.Logging.ILogger>(_loggerFactory.CreateLogger("Geocoder"));
+            services.AddSingleton<Microsoft.Extensions.Logging.ILogger>(sp =>
+                sp.GetRequiredService<ILoggerFactory>().CreateLogger("Geocoder"));
 
             services.AddMvc(config =>
             {

--- a/one-stop-service/Dockerfile.gha
+++ b/one-stop-service/Dockerfile.gha
@@ -1,0 +1,27 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY ["one-stop-service/one-stop-service.csproj", "one-stop-service/"]
+COPY ["cllc-interfaces/OneStopRestClient/OneStopRestClient.csproj", "cllc-interfaces/OneStopRestClient/"]
+COPY ["cllc-interfaces/Dynamics-Dataverse/Dynamics-Dataverse.csproj", "cllc-interfaces/Dynamics-Dataverse/"]
+
+RUN dotnet restore "one-stop-service/one-stop-service.csproj"
+
+COPY one-stop-service/ one-stop-service/
+COPY cllc-interfaces/ cllc-interfaces/
+
+WORKDIR "/src/one-stop-service"
+RUN dotnet build "one-stop-service.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "one-stop-service.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "one-stop-service.dll"]

--- a/one-stop-service/Startup.cs
+++ b/one-stop-service/Startup.cs
@@ -42,13 +42,11 @@ namespace Gov.Jag.Lcrb.OneStopService
 
     public class Startup
     {
-        private readonly ILoggerFactory _loggerFactory;
         public IConfiguration Configuration { get; }
         public IWebHostEnvironment Env { get; }
 
-        public Startup(IWebHostEnvironment env, ILoggerFactory loggerFactory)
+        public Startup(IWebHostEnvironment env)
         {
-            _loggerFactory = loggerFactory;
             var builder = new ConfigurationBuilder()
                 .SetBasePath(env.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
@@ -69,8 +67,6 @@ namespace Gov.Jag.Lcrb.OneStopService
         // This method gets called by the runtime. Use this method to add services to the container.
         public void ConfigureServices(IServiceCollection services)
         {
-            services.AddLogging(configure => configure.AddSerilog(dispose: true));
-
             // Adjust Kestrel options to allow sync IO
             services.Configure<KestrelServerOptions>(options =>
             {
@@ -85,7 +81,9 @@ namespace Gov.Jag.Lcrb.OneStopService
                 new ReceiveFromHubService(Configuration, Env, sp.GetRequiredService<IDataverseClient>()));
 
 
-            services.AddSingleton(_loggerFactory.CreateLogger("OneStopUtils"));
+            services.AddSingleton<Microsoft.Extensions.Logging.ILogger>(sp =>
+                sp.GetService<Microsoft.Extensions.Logging.ILoggerFactory>()?.CreateLogger("OneStopUtils")
+                ?? Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
             services.AddSingleton(Log.Logger);
 
             services.AddControllers(config =>
@@ -308,9 +306,8 @@ namespace Gov.Jag.Lcrb.OneStopService
             // by positioning this after the health check, no need to filter out health checks from request logging.
             app.UseSerilogRequestLogging();
 
-            app.UseMvc();
-
             app.UseRouting();
+            app.UseMvc();
             app.UseEndpoints(endpoints =>
             {
                 endpoints.UseSoapEndpoint<IReceiveFromHubService>("/receiveFromHub", new BasicHttpBinding(), SoapSerializer.XmlSerializer);

--- a/orgbook-service/Dockerfile.gha
+++ b/orgbook-service/Dockerfile.gha
@@ -1,0 +1,26 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY ["orgbook-service/orgbook-service.csproj", "orgbook-service/"]
+COPY ["cllc-interfaces/Dynamics-Dataverse/Dynamics-Dataverse.csproj", "cllc-interfaces/Dynamics-Dataverse/"]
+
+RUN dotnet restore "orgbook-service/orgbook-service.csproj"
+
+COPY orgbook-service/ orgbook-service/
+COPY cllc-interfaces/ cllc-interfaces/
+
+WORKDIR "/src/orgbook-service"
+RUN dotnet build "orgbook-service.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "orgbook-service.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "orgbook-service.dll"]

--- a/orgbook-service/Openshift.cs
+++ b/orgbook-service/Openshift.cs
@@ -10,6 +10,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Hosting.Server.Features;
 using Microsoft.AspNetCore.Server.Kestrel.Core;
+using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using RedHat.OpenShift.Utils;
@@ -23,7 +24,9 @@ namespace Gov.Lclb.Cllb.OrgbookService
 
 public static class PlatformEnvironment
 {
-    public static bool IsOpenShift => !string.IsNullOrEmpty(OpenShiftEnvironment.BuildName);
+    // KUBERNETES_SERVICE_HOST is present in every pod at runtime on any k8s/OpenShift cluster.
+    // OPENSHIFT_BUILD_NAME is only set during S2I builds, never at pod runtime — don't use it.
+    public static bool IsOpenShift => !string.IsNullOrEmpty(Environment.GetEnvironmentVariable("KUBERNETES_SERVICE_HOST"));
 }
 
 public static class OpenShiftEnvironment
@@ -102,10 +105,10 @@ internal class OpenShiftCertificateExpiration : Microsoft.Extensions.Hosting.Bac
     private static TimeSpan NotAfterMargin => TimeSpan.FromMinutes(15);
     private readonly IOptions<OpenShiftIntegrationOptions> _options;
     private readonly OpenShiftCertificateLoader _certificateLoader;
-    private readonly IApplicationLifetime _applicationLifetime;
+    private readonly IHostApplicationLifetime _applicationLifetime;
     private readonly ILogger<OpenShiftCertificateExpiration> _logger;
 
-    public OpenShiftCertificateExpiration(IOptions<OpenShiftIntegrationOptions> options, OpenShiftCertificateLoader certificateLoader, IApplicationLifetime applicationLifetime, ILogger<OpenShiftCertificateExpiration> logger)
+    public OpenShiftCertificateExpiration(IOptions<OpenShiftIntegrationOptions> options, OpenShiftCertificateLoader certificateLoader, IHostApplicationLifetime applicationLifetime, ILogger<OpenShiftCertificateExpiration> logger)
     {
         _options = options;
         _certificateLoader = certificateLoader;

--- a/orgbook-service/Startup.cs
+++ b/orgbook-service/Startup.cs
@@ -32,11 +32,9 @@ namespace Gov.Lclb.Cllb.OrgbookService
     public class Startup
     {
         public IConfiguration Configuration { get; }
-        public ILoggerFactory _loggerFactory;
 
-        public Startup(IWebHostEnvironment environment, ILoggerFactory loggerFactory)
+        public Startup(IWebHostEnvironment environment)
         {
-            _loggerFactory = loggerFactory;
             var builder = new ConfigurationBuilder()
                 .SetBasePath(environment.ContentRootPath)
                 .AddJsonFile("appsettings.json", optional: true, reloadOnChange: true);
@@ -96,7 +94,7 @@ namespace Gov.Lclb.Cllb.OrgbookService
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
             if (env.IsDevelopment())
             {
@@ -159,7 +157,7 @@ namespace Gov.Lclb.Cllb.OrgbookService
 
             if (!string.IsNullOrEmpty(Configuration["ENABLE_HANGFIRE_JOBS"]))
             {
-                SetupHangfireJobs(app);
+                SetupHangfireJobs(app, loggerFactory);
             }
 
             app.UseEndpoints(endpoints => 
@@ -204,30 +202,24 @@ namespace Gov.Lclb.Cllb.OrgbookService
         /// Setup the Hangfire jobs.
         /// </summary>
         /// <param name="app"></param>
-        private void SetupHangfireJobs(IApplicationBuilder app)
+        private void SetupHangfireJobs(IApplicationBuilder app, ILoggerFactory loggerFactory)
         {
             try
             {
                 using (var serviceScope = app.ApplicationServices.GetRequiredService<IServiceScopeFactory>().CreateScope())
                 {
-                    // _logger.LogInformation("Creating Hangfire jobs for License issuance check ...");
                     GenericRequest id = new GenericRequest() {
                         Id = Guid.NewGuid().ToString()
                     };
-                    //RecurringJob.AddOrUpdate(() => new OrgBookController(Configuration, _loggerFactory).SyncLicencesToOrgbook(id, null), Cron.MinuteInterval(5));
-                    //RecurringJob.AddOrUpdate(() => new OrgBookController(Configuration, _loggerFactory).SyncOrgbookToLicences(id, null), Cron.MinuteInterval(5));
-                    //RecurringJob.AddOrUpdate(() => new OrgBookController(Configuration, _loggerFactory).SyncOrgbookToAccounts(id, null), Cron.MinuteInterval(10));
-                    RecurringJob.AddOrUpdate(() => new OrgBookController(Configuration, _loggerFactory).SyncLicencesToOrgbook(id, null), Cron.Hourly());
-                    RecurringJob.AddOrUpdate(() => new OrgBookController(Configuration, _loggerFactory).SyncOrgbookToLicences(id, null), Cron.Hourly());
-                    RecurringJob.AddOrUpdate(() => new OrgBookController(Configuration, _loggerFactory).SyncOrgbookToAccounts(id, null), Cron.Daily());
+                    RecurringJob.AddOrUpdate(() => new OrgBookController(Configuration, loggerFactory).SyncLicencesToOrgbook(id, null), Cron.Hourly());
+                    RecurringJob.AddOrUpdate(() => new OrgBookController(Configuration, loggerFactory).SyncOrgbookToLicences(id, null), Cron.Hourly());
+                    RecurringJob.AddOrUpdate(() => new OrgBookController(Configuration, loggerFactory).SyncOrgbookToAccounts(id, null), Cron.Daily());
                 }
             }
             catch (Exception e)
             {
                 StringBuilder msg = new StringBuilder();
                 msg.AppendLine("Failed to setup Hangfire job.");
-
-                // _logger.LogCritical(new EventId(-1, "Hangfire job setup failed"), e, msg.ToString());
             }
         }
     }

--- a/pdf-service/Dockerfile.gha
+++ b/pdf-service/Dockerfile.gha
@@ -1,0 +1,39 @@
+FROM mcr.microsoft.com/dotnet/aspnet:8.0 AS base
+WORKDIR /app
+EXPOSE 8080
+ENV ASPNETCORE_URLS=http://*:8080
+
+# wkhtmltopdf system dependencies — must run as root before switching back to app user
+USER root
+RUN apt-get update && apt-get install -y \
+    fontconfig \
+    libfontconfig1 \
+    libfreetype6 \
+    libjpeg62-turbo \
+    libpng16-16 \
+    libssl3 \
+    bzip2 \
+    libstdc++6 \
+    libx11-6 \
+    libxext6 \
+    libxrender1 \
+    && rm -rf /var/lib/apt/lists/*
+USER app
+
+FROM mcr.microsoft.com/dotnet/sdk:8.0 AS build
+WORKDIR /src
+
+COPY ["pdf-service/pdf-service.csproj", "pdf-service/"]
+RUN dotnet restore "pdf-service/pdf-service.csproj"
+
+COPY pdf-service/ pdf-service/
+WORKDIR "/src/pdf-service"
+RUN dotnet build "pdf-service.csproj" -c Release -o /app/build
+
+FROM build AS publish
+RUN dotnet publish "pdf-service.csproj" -c Release -o /app/publish
+
+FROM base AS final
+WORKDIR /app
+COPY --from=publish /app/publish .
+ENTRYPOINT ["dotnet", "pdf-service.dll"]


### PR DESCRIPTION
- Created CI workflows for cllc-public-frontend, federal-reporting-service, file-manager-service, geocoder-service, one-stop-service, orgbook-service, and pdf-service to automate build and deployment processes.
- Added Dockerfiles for each service to define the build and runtime environments.
- Introduced .dockerignore files to exclude unnecessary files from Docker builds.
- Configured nginx for serving the Angular frontend and proxying API requests to backend services.
- Set up a local development environment using docker-compose for easier testing and development.