### PR TITLE
LCSD-8633 custom cron schedule and new default for Fed Rpt Export

### DIFF
--- a/federal-reporting-service/Startup.cs
+++ b/federal-reporting-service/Startup.cs
@@ -214,8 +214,15 @@ namespace Gov.Lclb.Cllb.FederalReportingService
                 {
                     log.LogInformation($"Creating Hangfire jobs for {typeof(Startup)} ...");
 
-                    // Run every 10 minutes
-                    RecurringJob.AddOrUpdate(() => new FederalReportingController(Configuration, loggerFactory, _fileManagerClient).ExportFederalReports(null), "*/10 * * * *");
+                    // Run at specified interval with default to hourly at 0 minutes past the hour, but allow override via configuration.
+                    string interval = Cron.Hourly();
+                    if (!string.IsNullOrEmpty(Configuration["QUEUE_CHECK_INTERVAL"]))
+                    {
+                        interval = (Configuration["QUEUE_CHECK_INTERVAL"]);
+                    }
+                    log.LogInformation($"Using interval: {interval}");
+
+                    RecurringJob.AddOrUpdate(() => new FederalReportingController(Configuration, loggerFactory, _fileManagerClient).ExportFederalReports(null), interval);
 
                     log.LogInformation("Hangfire jobs setup.");
                 }


### PR DESCRIPTION
Change pick interval from 10 min to 1 hr.

Also allow use of env var QUEUE_CHECK_INTERVAL to customize the pickup interval. Restart is required. (see OneStop service for usage)