### PR TITLE
LCSD-8633 LCSD-8322 Federal Report Export, Ethyl Alcohol Permit

### DIFF
--- a/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.html
+++ b/cllc-public-app/ClientApp/src/app/components/account-profile/account-profile.component.html
@@ -472,7 +472,7 @@
                   [application]="application"
                   (onFormChanges)="connectionToProducersFormData = $event"></app-connection-to-producers>
               </div>
-              <div>
+              <div *ngIf="application?.applicationType?.name !== 'Ethyl Alcohol Permit'">
                 <app-connection-to-other-liquor-licences
                   [account]="account"
                   [application]="application"

--- a/federal-reporting-service/Startup.cs
+++ b/federal-reporting-service/Startup.cs
@@ -214,8 +214,15 @@ namespace Gov.Lclb.Cllb.FederalReportingService
                 {
                     log.LogInformation($"Creating Hangfire jobs for {typeof(Startup)} ...");
 
-                    // Run every 10 minutes
-                    RecurringJob.AddOrUpdate(() => new FederalReportingController(Configuration, loggerFactory, _fileManagerClient).ExportFederalReports(null), "*/10 * * * *");
+                    // Run at specified interval with default to hourly at 0 minutes past the hour, but allow override via configuration.
+                    string interval = Cron.Hourly();
+                    if (!string.IsNullOrEmpty(Configuration["QUEUE_CHECK_INTERVAL"]))
+                    {
+                        interval = (Configuration["QUEUE_CHECK_INTERVAL"]);
+                    }
+                    log.LogInformation($"Using interval: {interval}");
+
+                    RecurringJob.AddOrUpdate(() => new FederalReportingController(Configuration, loggerFactory, _fileManagerClient).ExportFederalReports(null), interval);
 
                     log.LogInformation("Hangfire jobs setup.");
                 }


### PR DESCRIPTION
LCSD-8633 Change Federal Report Export frequency from 10 min to 1 hr, and allow schedule customization

LCSD-8322 Do not show liquor tied house section in account profile review for Ethyl Alcohol Permit